### PR TITLE
ci: use self-hosted ARM64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,8 @@ jobs:
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@latest
 
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@v1
-        with:
-          chrome-version: stable
+      - name: Install Chromium (ARM64 compatible)
+        run: sudo apt-get update && sudo apt-get install -y chromium-browser
 
       - name: Generate templ
         run: templ generate


### PR DESCRIPTION
## Summary
- Replace `ubuntu-latest` with self-hosted Linux ARM64 runners for all CI jobs
- Affects build, unit-tests, integration-tests, e2e-tests, and docker jobs

## Benefits
- Cost savings by leveraging self-hosted infrastructure
- Consistent build environment
- Better control over runner resources

Closes #3