### PR TITLE
fix: resolve CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
+          cache: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -64,6 +65,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
+          cache: false
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@latest
@@ -91,6 +93,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
+          cache: false
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@latest
@@ -118,6 +121,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
+          cache: false
 
       - name: Install templ
         run: go install github.com/a-h/templ/cmd/templ@latest
@@ -175,7 +179,7 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@v3.0.0
         with:
-          additionalArguments: '/overrideconfig mode=Mainline'
+          overrideConfig: 'mode=Mainline'
 
       - name: Display GitVersion outputs
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -o /bin/server .
 
 # Stage 3: Production image (target platform)
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /
 COPY --from=builder /bin/server /server
 COPY --from=builder /app/assets/ /assets/


### PR DESCRIPTION
## Summary
- Remove redundant `--platform=$TARGETPLATFORM` from Dockerfile final stage (default behavior)
- Fix GitVersion action input: `additionalArguments` → `overrideConfig`
- Disable Go module cache on self-hosted runners to avoid tar restore conflicts

## Warnings Fixed
| Warning | Fix |
|---------|-----|
| RedundantTargetPlatform (Dockerfile:35) | Removed `--platform=$TARGETPLATFORM` |
| Unexpected input 'additionalArguments' | Changed to `overrideConfig` |
| tar restore failed | Added `cache: false` to setup-go |