### PR TITLE
fix: implement working dark/light mode toggle switch

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -216,11 +216,11 @@ func TestE2EAlpineJSInitialization(t *testing.T) {
 	err = chromedp.Run(ctx,
 		chromedp.Evaluate(`
 			(function() {
-				const html = document.documentElement;
-				return html.__x !== undefined || html._x_dataStack !== undefined;
+				const body = document.body;
+				return body.__x !== undefined || body._x_dataStack !== undefined;
 			})()
 		`, &themeStateExists),
 	)
 	require.NoError(t, err)
-	assert.True(t, themeStateExists, "Alpine.js should have initialized on html element")
+	assert.True(t, themeStateExists, "Alpine.js should have initialized on body element")
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -367,7 +367,7 @@ func TestAlpineJSIntegration(t *testing.T) {
 	})
 
 	t.Run("theme toggle uses Alpine", func(t *testing.T) {
-		assert.Contains(t, html, "$root.dark")
+		assert.Contains(t, html, `@click="dark = !dark"`)
 	})
 
 	t.Run("x-cloak style defined", func(t *testing.T) {
@@ -456,7 +456,7 @@ func TestAlpineHTMXSeparation(t *testing.T) {
 		assert.Contains(t, html, "x-show", "Alpine x-show for visibility")
 		assert.Contains(t, html, "@click", "Alpine @click for events")
 		assert.Contains(t, html, "mobileOpen", "Alpine state for mobile menu")
-		assert.Contains(t, html, "$root.dark", "Alpine state for theme")
+		assert.Contains(t, html, `@click="dark = !dark"`, "Alpine state for theme")
 	})
 
 	t.Run("HTMX ready for server-side interactions", func(t *testing.T) {

--- a/views/layout.templ
+++ b/views/layout.templ
@@ -2,17 +2,7 @@ package views
 
 templ Layout(title string) {
 	<!DOCTYPE html>
-	<html
-		lang="en"
-		class="scroll-smooth"
-		x-data="{
-			dark: localStorage.getItem('theme') === 'dark' ||
-				(!localStorage.getItem('theme') &&
-				 window.matchMedia('(prefers-color-scheme: dark)').matches)
-		}"
-		:class="{ 'dark': dark }"
-		x-init="$watch('dark', value => localStorage.setItem('theme', value ? 'dark' : 'light'))"
-	>
+	<html lang="en" class="scroll-smooth">
 		<head>
 			<meta charset="UTF-8"/>
 			<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -24,10 +14,28 @@ templ Layout(title string) {
 			<link rel="apple-touch-icon" href="/assets/img/apple-touch-icon.png"/>
 			<link rel="manifest" href="/manifest.webmanifest"/>
 			<link rel="stylesheet" href="/assets/styles.css"/>
+			<script>
+				if (localStorage.getItem('theme') === 'dark' ||
+					(!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+					document.documentElement.classList.add('dark');
+				}
+			</script>
 			<script src="/assets/js/htmx.min.js"></script>
 			<script defer src="/assets/js/alpine.min.js"></script>
 		</head>
-		<body class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors duration-300">
+		<body
+			class="bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors duration-300"
+			x-data="{
+				dark: localStorage.getItem('theme') === 'dark' ||
+					(!localStorage.getItem('theme') &&
+					 window.matchMedia('(prefers-color-scheme: dark)').matches)
+			}"
+			x-init="$watch('dark', value => {
+				localStorage.setItem('theme', value ? 'dark' : 'light');
+				document.documentElement.classList.toggle('dark', value);
+			})"
+			x-effect="document.documentElement.classList.toggle('dark', dark)"
+		>
 			@Nav()
 			<main>
 				{ children... }
@@ -101,16 +109,23 @@ templ Nav() {
 
 templ ThemeToggle() {
 	<button
-		@click="$root.dark = !$root.dark"
-		class="p-2 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+		@click="dark = !dark"
+		class="relative w-16 h-8 rounded-full bg-gray-200 dark:bg-gray-700 transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
 		aria-label="Toggle theme"
+		role="switch"
+		:aria-checked="dark"
 	>
-		<svg x-show="$root.dark" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-			<path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path>
-		</svg>
-		<svg x-show="!$root.dark" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-			<path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
-		</svg>
+		<span
+			class="absolute left-1 top-1 w-6 h-6 rounded-full bg-white shadow-md transform transition-transform duration-300 flex items-center justify-center"
+			:class="{ 'translate-x-8': dark }"
+		>
+			<svg x-show="!dark" class="w-4 h-4 text-amber-500" fill="currentColor" viewBox="0 0 20 20">
+				<path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"></path>
+			</svg>
+			<svg x-show="dark" x-cloak class="w-4 h-4 text-indigo-400" fill="currentColor" viewBox="0 0 20 20">
+				<path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
+			</svg>
+		</span>
 	</button>
 }
 

--- a/views/layout_templ.go
+++ b/views/layout_templ.go
@@ -29,20 +29,20 @@ func Layout(title string) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\" class=\"scroll-smooth\" x-data=\"{\n\t\t\tdark: localStorage.getItem('theme') === 'dark' ||\n\t\t\t\t(!localStorage.getItem('theme') &&\n\t\t\t\t window.matchMedia('(prefers-color-scheme: dark)').matches)\n\t\t}\" :class=\"{ 'dark': dark }\" x-init=\"$watch('dark', value => localStorage.setItem('theme', value ? 'dark' : 'light'))\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><meta name=\"description\" content=\"Enterprise Kubernetes Platform - Hybrid Cloud & Edge Computing with full infrastructure ownership\"><meta name=\"theme-color\" content=\"#06b6d4\"><title>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\" class=\"scroll-smooth\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"><meta name=\"description\" content=\"Enterprise Kubernetes Platform - Hybrid Cloud & Edge Computing with full infrastructure ownership\"><meta name=\"theme-color\" content=\"#06b6d4\"><title>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout.templ`, Line: 21, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/layout.templ`, Line: 11, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><link rel=\"icon\" href=\"/assets/img/favicon.ico\" sizes=\"32x32\"><link rel=\"icon\" href=\"/assets/img/icon.svg\" type=\"image/svg+xml\"><link rel=\"apple-touch-icon\" href=\"/assets/img/apple-touch-icon.png\"><link rel=\"manifest\" href=\"/manifest.webmanifest\"><link rel=\"stylesheet\" href=\"/assets/styles.css\"><script src=\"/assets/js/htmx.min.js\"></script><script defer src=\"/assets/js/alpine.min.js\"></script></head><body class=\"bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors duration-300\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</title><link rel=\"icon\" href=\"/assets/img/favicon.ico\" sizes=\"32x32\"><link rel=\"icon\" href=\"/assets/img/icon.svg\" type=\"image/svg+xml\"><link rel=\"apple-touch-icon\" href=\"/assets/img/apple-touch-icon.png\"><link rel=\"manifest\" href=\"/manifest.webmanifest\"><link rel=\"stylesheet\" href=\"/assets/styles.css\"><script>\n\t\t\t\tif (localStorage.getItem('theme') === 'dark' ||\n\t\t\t\t\t(!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {\n\t\t\t\t\tdocument.documentElement.classList.add('dark');\n\t\t\t\t}\n\t\t\t</script><script src=\"/assets/js/htmx.min.js\"></script><script defer src=\"/assets/js/alpine.min.js\"></script></head><body class=\"bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors duration-300\" x-data=\"{\n\t\t\t\tdark: localStorage.getItem('theme') === 'dark' ||\n\t\t\t\t\t(!localStorage.getItem('theme') &&\n\t\t\t\t\t window.matchMedia('(prefers-color-scheme: dark)').matches)\n\t\t\t}\" x-init=\"$watch('dark', value => {\n\t\t\t\tlocalStorage.setItem('theme', value ? 'dark' : 'light');\n\t\t\t\tdocument.documentElement.classList.toggle('dark', value);\n\t\t\t})\" x-effect=\"document.documentElement.classList.toggle('dark', dark)\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -132,7 +132,7 @@ func ThemeToggle() templ.Component {
 			templ_7745c5c3_Var4 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<button @click=\"$root.dark = !$root.dark\" class=\"p-2 rounded-lg bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors\" aria-label=\"Toggle theme\"><svg x-show=\"$root.dark\" class=\"w-5 h-5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z\"></path></svg> <svg x-show=\"!$root.dark\" class=\"w-5 h-5\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\" stroke-width=\"2\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" d=\"M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z\"></path></svg></button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<button @click=\"dark = !dark\" class=\"relative w-16 h-8 rounded-full bg-gray-200 dark:bg-gray-700 transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-cyan-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900\" aria-label=\"Toggle theme\" role=\"switch\" :aria-checked=\"dark\"><span class=\"absolute left-1 top-1 w-6 h-6 rounded-full bg-white shadow-md transform transition-transform duration-300 flex items-center justify-center\" :class=\"{ 'translate-x-8': dark }\"><svg x-show=\"!dark\" class=\"w-4 h-4 text-amber-500\" fill=\"currentColor\" viewBox=\"0 0 20 20\"><path fill-rule=\"evenodd\" d=\"M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z\" clip-rule=\"evenodd\"></path></svg> <svg x-show=\"dark\" x-cloak class=\"w-4 h-4 text-indigo-400\" fill=\"currentColor\" viewBox=\"0 0 20 20\"><path d=\"M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z\"></path></svg></span></button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary
- Fix the theme toggle button that wasn't working (clicking did nothing)
- Replace icon button with a proper pill-shaped toggle switch
- Move Alpine.js state from `<html>` to `<body>` for proper scoping

## Changes
| Before | After |
|--------|-------|
| Icon button that didn't work | Pill-shaped toggle switch |
| `x-data` on `<html>` (scope issues) | `x-data` on `<body>` (works properly) |
| `$root.dark` reference | Direct `dark` reference |
| Outline icons | Filled icons with colors |

## Technical Details
The root cause was Alpine.js `x-data` on `<html>` not properly working with `$root` references from nested components. Moving the state to `<body>` and using `x-effect` to sync the `.dark` class to `documentElement` fixes the issue.

## UI
- **Light mode**: Sun icon (amber) on left side of toggle
- **Dark mode**: Moon icon (indigo) on right side of toggle
- Sliding animation when toggling
- Proper ARIA attributes (`role="switch"`, `:aria-checked`)

Fixes #7