### PR TITLE
fix(release): use --output-bundle for cosign v3 bundle format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,7 @@ sboms:
 
 signs:
   - cmd: cosign
-    args: ["sign-blob", "--yes", "--output-signature", "${signature}", "${artifact}"]
+    args: ["sign-blob", "--yes", "--output-bundle", "${signature}", "${artifact}"]
     artifacts: checksum
 
 changelog:


### PR DESCRIPTION
## Summary
- Replace `--output-signature` with `--output-bundle` in `.goreleaser.yaml` signs config
- cosign v3 (installed by `sigstore/cosign-installer@v4.1.1`) defaults to `--new-bundle-format`, which deprecates `--output-signature`. The old flag is silently ignored, leaving an empty output path and causing `create bundle file: open : no such file or directory`
- `--output-bundle` is the correct flag for the bundle format, writing to the `${signature}` path GoReleaser expects

## Test plan
- Merge this PR, then push a new tag (e.g. `v0.0.4`) to trigger the Release workflow
- Verify both `release` and `docker-release` jobs succeed