### PR TITLE
fix(ci): use PR number for preview environment image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           push_image: true
           tag_list: |
-            pr-${{ github.run_number }}-${{ github.sha }}
-          version: pr-${{ github.run_number }}
+            pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+          version: pr-${{ github.event.pull_request.number }}
           git_commit: ${{ github.sha }}
           build_time: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
 
   docker-pr:
     needs: [build, test, e2e-test]
-    if: github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request' && needs.build.result == 'success' && needs.test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           push_image: true
           tag_list: |
-            pr-${{ github.event.pull_request.number }}-${{ github.sha }}
+            pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           version: pr-${{ github.event.pull_request.number }}
-          git_commit: ${{ github.sha }}
+          git_commit: ${{ github.event.pull_request.head.sha }}
           build_time: ""


### PR DESCRIPTION
## Summary

- Fix Docker image tag format in the `docker-pr` CI job to use `github.event.pull_request.number` instead of `github.run_number`
- The Flux ResourceSet template expects `pr-{PR_NUMBER}-{SHA}` but CI was producing `pr-{RUN_NUMBER}-{SHA}` — these are different values
- This fix ensures ephemeral preview environments can correctly pull the Docker image built for each PR

## Test plan

- [ ] Verify CI builds image with correct `pr-{PR_NUMBER}-{sha}` tag
- [ ] Verify Flux ResourceSetInputProvider detects this PR
- [ ] Verify preview environment is accessible at `pr{N}.dev.rezus.cloud`