### PR TITLE
ci: fix build on ARC runner — replace make with direct go build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: go vet ./...
 
       - name: Build binary
-        run: make build
+        run: CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=dev -X main.gitCommit=$(git rev-parse --short HEAD) -X main.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -trimpath -o bin/server .
 
   test:
     needs: build


### PR DESCRIPTION
## Problem
Master CI fails with `make: command not found` on the ARC Kubernetes runner (`rezuscloud-amd64-*`).

The `make build` step relies on `make` which is not installed in the ARC runner image. The self-hosted `tib-archbee` runner has `make` but the ARC runner doesn't.

## Fix
Replace `make build` with the direct `CGO_ENABLED=0 go build` command. This is safe because the `setup-build` composite action already runs `templ generate` and CSS build separately — the Makefile's `build` target just re-runs those (redundantly) plus the Go compile.

## Test plan
- [ ] CI passes on this PR (including the build step)