### PR TITLE
fix: add conventional-changelog-conventionalcommits for semantic-release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "@tailwindcss/cli": "^4.1.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "semantic-release": "^24.2.7",
         "tailwindcss": "^4.1.0"
       }
@@ -1406,6 +1407,19 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
       "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "compare-func": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/conventional-changelog-conventionalcommits": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "release:dry-run": "semantic-release --dry-run"
   },
   "devDependencies": {
-    "@tailwindcss/cli": "^4.1.0",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/release-notes-generator": "^14.1.0",
+    "@tailwindcss/cli": "^4.1.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "semantic-release": "^24.2.7",
     "tailwindcss": "^4.1.0"
   }


### PR DESCRIPTION
## Problem\nsemantic-release fails with `Cannot find module 'conventional-changelog-conventionalcommits'`.\n\n## Fix\nAdd `conventional-changelog-conventionalcommits` to devDependencies.\n\n## Test plan\n- [ ] CI passes\n- [ ] After merge, semantic-release creates a tag on master