### PR TITLE
ci: move all workflows to self-hosted runners

### DIFF
--- a/.github/actions/docker-multiarch/action.yml
+++ b/.github/actions/docker-multiarch/action.yml
@@ -80,8 +80,6 @@ runs:
         context: .
         push: ${{ inputs.push_image }}
         tags: ${{ steps.prep.outputs.tags }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         platforms: linux/amd64,linux/arm64
         provenance: false
         sbom: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
   docker-pr:
     needs: [build, test, e2e-test]
     if: always() && github.event_name == 'pull_request' && needs.build.result == 'success' && needs.test.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -28,12 +28,12 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: "1.24"
+          cache: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-          cache: npm
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -18,7 +18,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'master'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "22"
-          cache: npm
 
       - name: Install npm dependencies
         run: npm ci


### PR DESCRIPTION
## Problem
Three jobs still run on `ubuntu-latest` (GitHub-hosted runners):
- `docker-pr` (CI preview builds)
- `release` (GoReleaser)
- `semantic-release`

## Changes
- Move all three to `[self-hosted, Linux, X64]`
- Disable `cache: npm` / `cache: gha` for self-hosted runners (persistent storage)
- Remove `cache-from: type=gha` / `cache-to: type=gha` from `docker-multiarch` action

## Test plan
- [ ] CI passes on this PR (all jobs on self-hosted runners)