### PR TITLE
ci: let semantic-release publish via GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Git ref to publish (tag, branch, or SHA)
+        description: Git ref to validate in snapshot mode
         required: false
         default: master
-      snapshot:
-        description: Snapshot mode (skip publish)
-        type: boolean
-        default: false
 
 permissions:
   contents: write
@@ -25,70 +21,90 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
+  publish:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'master')
-    runs-on: ubuntu-latest
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master'
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
+          cache: false
 
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
-          cache: npm
 
       - run: npm ci
 
-      - name: Resolve release ref
-        id: resolve
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            git checkout "${{ github.event.inputs.ref || 'master' }}"
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git checkout -B master "${{ github.event.workflow_run.head_sha }}"
-          npx semantic-release
-          git fetch --tags origin
-          if git tag --points-at HEAD --list 'v*' | grep -q .; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Log in to GHCR
-        if: steps.resolve.outputs.publish == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        if: steps.resolve.outputs.publish == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
-      - uses: sigstore/cosign-installer@v4.1.1
-        if: steps.resolve.outputs.publish == 'true'
-
-      - uses: anchore/sbom-action/download-syft@v0
-        if: steps.resolve.outputs.publish == 'true'
-
-      - name: Run GoReleaser
-        if: steps.resolve.outputs.publish == 'true'
+      - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: ${{ github.event.inputs.snapshot == 'true' && 'release --snapshot --clean' || 'release --clean' }}
+          install-only: true
+
+      - uses: sigstore/cosign-installer@v4.1.1
+
+      - uses: anchore/sbom-action/download-syft@v0
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release
+
+  snapshot:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || 'master' }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+          cache: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - uses: sigstore/cosign-installer@v4.1.1
+
+      - uses: anchore/sbom-action/download-syft@v0
+
+      - name: Run GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,6 +13,12 @@
       {
         "preset": "conventionalcommits"
       }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "cat > /tmp/release-notes.md <<'EOF'\n${nextRelease.notes}\nEOF\ngoreleaser release --release-notes /tmp/release-notes.md --clean"
+      }
     ]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "platform-website",
       "devDependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
+        "@semantic-release/exec": "^7.1.0",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "@tailwindcss/cli": "^4.1.0",
         "conventional-changelog-conventionalcommits": "^9.3.1",
@@ -666,6 +667,61 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-7.1.0.tgz",
+      "integrity": "sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^9.0.0",
+        "lodash-es": "^4.17.21",
+        "parse-json": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.8.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=24.1.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@semantic-release/github": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "scripts": {
     "build:css": "npx @tailwindcss/cli -i input.css -o assets/styles.css --minify",
     "watch:css": "npx @tailwindcss/cli -i input.css -o assets/styles.css --watch",
-    "release:dry-run": "semantic-release --dry-run"
+    "release:dry-run": "semantic-release --dry-run",
+    "release": "semantic-release"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^13.0.1",
+    "@semantic-release/exec": "^7.1.0",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "@tailwindcss/cli": "^4.1.0",
     "conventional-changelog-conventionalcommits": "^9.3.1",


### PR DESCRIPTION
## Summary
- switch to the documented GoReleaser + semantic-release integration pattern
- run `goreleaser release` from `@semantic-release/exec` during the semantic-release publish step
- keep `workflow_dispatch` only for snapshot validation of the release pipeline
- remove the fragile downstream tag-trigger dependency that required a second workflow to react to a tag push

## Why
The current flow still depended on a tag push triggering another workflow. When semantic-release created the tag with the workflow token, GitHub did not fire the downstream release workflow automatically. This left the repo tagged without a real published release or deployment artifact.

This change makes release publication a single automatic path after green CI on `master`:
1. CI succeeds on `master`
2. release workflow runs
3. semantic-release computes the next version and creates the tag
4. semantic-release publish step invokes GoReleaser directly
5. GoReleaser publishes the GitHub release and container images

## Validation
- `npx semantic-release --dry-run`