### PR TITLE
ci: install envsubst before cosign setup on self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,5 +168,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          gh label create preview-ready --color 0e8a16 --description "Preview image published successfully" --force
           gh api --silent --method POST repos/${{ github.repository }}/issues/${PR_NUMBER}/labels -f labels[]=preview-ready

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  preview-reset:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Remove preview-ready label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh api --silent --method DELETE repos/${{ github.repository }}/issues/${PR_NUMBER}/labels/preview-ready || true
-
   build:
     runs-on: [self-hosted, Linux, X64]
     permissions:
@@ -146,12 +134,11 @@ jobs:
         run: docker stop platform-website && docker rm platform-website || true
 
   docker-pr:
-    needs: [preview-reset, build, test, e2e-test]
-    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.preview-reset.result == 'success' && needs.build.result == 'success' && needs.test.result == 'success' && needs.e2e-test.result == 'success'
+    needs: [build, test, e2e-test]
+    if: always() && github.event_name == 'pull_request' && needs.build.result == 'success' && needs.test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
       packages: write
     steps:
       - uses: actions/checkout@v6
@@ -163,9 +150,3 @@ jobs:
           version: pr-${{ github.event.pull_request.number }}
           git_commit: ${{ github.event.pull_request.head.sha }}
           build_time: ""
-      - name: Mark preview ready
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          gh api --silent --method POST repos/${{ github.repository }}/issues/${PR_NUMBER}/labels -f labels[]=preview-ready

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,18 @@ on:
   workflow_dispatch:
 
 jobs:
+  preview-reset:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Remove preview-ready label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh api --silent --method DELETE repos/${{ github.repository }}/issues/${PR_NUMBER}/labels/preview-ready || true
+
   build:
     runs-on: [self-hosted, Linux, X64]
     permissions:
@@ -134,11 +146,12 @@ jobs:
         run: docker stop platform-website && docker rm platform-website || true
 
   docker-pr:
-    needs: [build, test, e2e-test]
-    if: always() && github.event_name == 'pull_request' && needs.build.result == 'success' && needs.test.result == 'success'
+    needs: [preview-reset, build, test, e2e-test]
+    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.preview-reset.result == 'success' && needs.build.result == 'success' && needs.test.result == 'success' && needs.e2e-test.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
       packages: write
     steps:
       - uses: actions/checkout@v6
@@ -150,3 +163,10 @@ jobs:
           version: pr-${{ github.event.pull_request.number }}
           git_commit: ${{ github.event.pull_request.head.sha }}
           build_time: ""
+      - name: Mark preview ready
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh label create preview-ready --color 0e8a16 --description "Preview image published successfully" --force
+          gh api --silent --method POST repos/${{ github.repository }}/issues/${PR_NUMBER}/labels -f labels[]=preview-ready

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
           version: "~> v2"
           install-only: true
 
+      - name: Install gettext-base
+        run: which envsubst || (sudo apt-get update -q && sudo apt-get install -y gettext-base)
+
       - uses: sigstore/cosign-installer@v4.1.1
 
       - uses: anchore/sbom-action/download-syft@v0
@@ -96,6 +99,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Install gettext-base
+        run: which envsubst || (sudo apt-get update -q && sudo apt-get install -y gettext-base)
 
       - uses: sigstore/cosign-installer@v4.1.1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: Git ref to publish (tag, branch, or SHA)
+        description: Git ref to validate in snapshot mode
         required: false
         default: master
-      snapshot:
-        description: Snapshot mode (skip publish)
-        type: boolean
-        default: false
 
 permissions:
   contents: write
@@ -25,70 +21,90 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
+  publish:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_branch == 'master')
-    runs-on: ubuntu-latest
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master'
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - uses: actions/setup-go@v6
         with:
           go-version: "1.24"
+          cache: false
 
       - uses: actions/setup-node@v6
         with:
           node-version: "22"
-          cache: npm
 
       - run: npm ci
 
-      - name: Resolve release ref
-        id: resolve
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            git checkout "${{ github.event.inputs.ref || 'master' }}"
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git checkout -B master "${{ github.event.workflow_run.head_sha }}"
-          npx semantic-release
-          git fetch --tags origin
-          if git tag --points-at HEAD --list 'v*' | grep -q .; then
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Log in to GHCR
-        if: steps.resolve.outputs.publish == 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        if: steps.resolve.outputs.publish == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
-      - uses: sigstore/cosign-installer@v4.1.1
-        if: steps.resolve.outputs.publish == 'true'
-
-      - uses: anchore/sbom-action/download-syft@v0
-        if: steps.resolve.outputs.publish == 'true'
-
-      - name: Run GoReleaser
-        if: steps.resolve.outputs.publish == 'true'
+      - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
-          args: ${{ github.event.inputs.snapshot == 'true' && 'release --snapshot --clean' || 'release --clean' }}
+          install-only: true
+
+      - uses: sigstore/cosign-installer@v4.1.1
+
+      - uses: anchore/sbom-action/download-syft@v0
+
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx semantic-release
+
+  snapshot:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, Linux, X64]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || 'master' }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+          cache: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - uses: sigstore/cosign-installer@v4.1.1
+
+      - uses: anchore/sbom-action/download-syft@v0
+
+      - name: Run GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.opencode-preview-validation
+++ b/.opencode-preview-validation
@@ -1,0 +1,1 @@
+preview-ready validation trigger

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,6 +13,12 @@
       {
         "preset": "conventionalcommits"
       }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "cat > /tmp/release-notes.md <<'EOF'\n${nextRelease.notes}\nEOF\ngoreleaser release --release-notes /tmp/release-notes.md --clean"
+      }
     ]
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "platform-website",
       "devDependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
+        "@semantic-release/exec": "^7.1.0",
         "@semantic-release/release-notes-generator": "^14.1.0",
         "@tailwindcss/cli": "^4.1.0",
         "conventional-changelog-conventionalcommits": "^9.3.1",
@@ -666,6 +667,61 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/exec": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/exec/-/exec-7.1.0.tgz",
+      "integrity": "sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^3.0.0",
+        "debug": "^4.0.0",
+        "execa": "^9.0.0",
+        "lodash-es": "^4.17.21",
+        "parse-json": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.8.1"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=24.1.0"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@semantic-release/exec/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@semantic-release/github": {

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "scripts": {
     "build:css": "npx @tailwindcss/cli -i input.css -o assets/styles.css --minify",
     "watch:css": "npx @tailwindcss/cli -i input.css -o assets/styles.css --watch",
-    "release:dry-run": "semantic-release --dry-run"
+    "release:dry-run": "semantic-release --dry-run",
+    "release": "semantic-release"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^13.0.1",
+    "@semantic-release/exec": "^7.1.0",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "@tailwindcss/cli": "^4.1.0",
     "conventional-changelog-conventionalcommits": "^9.3.1",


### PR DESCRIPTION
The automatic release workflow now runs fully on self-hosted runners.  expects , which is not preinstalled there, so the release job fails before semantic-release can publish. Install  first.