### PR TITLE
ci: install envsubst before cosign setup on self-hosted runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,9 @@ jobs:
           version: "~> v2"
           install-only: true
 
+      - name: Install gettext-base
+        run: which envsubst || (sudo apt-get update -q && sudo apt-get install -y gettext-base)
+
       - uses: sigstore/cosign-installer@v4.1.1
 
       - uses: anchore/sbom-action/download-syft@v0
@@ -96,6 +99,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Install gettext-base
+        run: which envsubst || (sudo apt-get update -q && sudo apt-get install -y gettext-base)
 
       - uses: sigstore/cosign-installer@v4.1.1
 


### PR DESCRIPTION
Install  before  in the self-hosted release workflow so  is available and the automatic release job can proceed into semantic-release and GoReleaser.