### PR TITLE
fix(ci): manage preview readiness from trusted workflow

### DIFF
--- a/.github/workflows/preview-ready.yml
+++ b/.github/workflows/preview-ready.yml
@@ -1,0 +1,54 @@
+name: Preview Ready
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  actions: read
+  issues: write
+
+jobs:
+  clear:
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove preview-ready label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh api --silent --method DELETE repos/${{ github.repository }}/issues/${PR_NUMBER}/labels/preview-ready || true
+
+  mark:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark preview ready after successful docker-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+
+          run_payload="$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID})"
+          pr_number="$(jq -r '.pull_requests[0].number // empty' <<< "$run_payload")"
+          head_sha="$(jq -r '.head_sha' <<< "$run_payload")"
+
+          if [ -z "$pr_number" ] || [ -z "$head_sha" ]; then
+            exit 0
+          fi
+
+          docker_pr_conclusion="$(gh api repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs --paginate --jq '.jobs[] | select(.name == "docker-pr") | .conclusion' | tail -n 1)"
+
+          if [ "$docker_pr_conclusion" != "success" ]; then
+            exit 0
+          fi
+
+          docker buildx imagetools inspect "ghcr.io/${{ github.repository }}:pr-${pr_number}-${head_sha}"
+          gh api --silent --method POST repos/${{ github.repository }}/issues/${pr_number}/labels -f labels[]=preview-ready


### PR DESCRIPTION
## Summary
- clear preview readiness on PR updates from a trusted workflow
- re-add preview readiness only after a successful CI preview image publish
- keep pull request CI limited to publishing the preview image itself
