### PR TITLE
ci: move all workflows to self-hosted runners

### DIFF
--- a/.github/actions/docker-multiarch/action.yml
+++ b/.github/actions/docker-multiarch/action.yml
@@ -101,6 +101,14 @@ runs:
         echo "$platforms" | grep -qx 'linux/amd64'
         echo "$platforms" | grep -qx 'linux/arm64'
 
+    - name: Install file utility
+      if: ${{ inputs.push_image == 'true' }}
+      shell: bash
+      run: |
+        if ! command -v file &>/dev/null; then
+          apt-get update -qq && apt-get install -y -qq file
+        fi
+
     - name: Verify binary architecture per platform
       if: ${{ inputs.push_image == 'true' }}
       shell: bash

--- a/.github/actions/docker-multiarch/action.yml
+++ b/.github/actions/docker-multiarch/action.yml
@@ -106,7 +106,7 @@ runs:
       shell: bash
       run: |
         if ! command -v file &>/dev/null; then
-          apt-get update -qq && apt-get install -y -qq file
+          sudo apt-get update -qq && sudo apt-get install -y -qq file
         fi
 
     - name: Verify binary architecture per platform

--- a/.github/actions/docker-multiarch/action.yml
+++ b/.github/actions/docker-multiarch/action.yml
@@ -77,8 +77,6 @@ runs:
         context: .
         push: ${{ inputs.push_image }}
         tags: ${{ steps.prep.outputs.tags }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         platforms: linux/amd64,linux/arm64
         provenance: false
         sbom: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
   docker-pr:
     needs: [build, test, e2e-test]
     if: always() && needs.build.result == 'success' && needs.test.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/preview-ready.yml
+++ b/.github/workflows/preview-ready.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   clear:
     if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Remove preview-ready label
         env:
@@ -26,7 +26,7 @@ jobs:
 
   mark:
     if: github.event_name == 'workflow_run'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Mark preview ready after successful docker-pr
         env:


### PR DESCRIPTION
## Summary

Closes #46.

Clean rebase from current master. The original PR branch had conflicts from CI evolution on master. This applies only the remaining changes needed.

### Changes

| File | Change |
|---|---|
| `ci.yml` | `docker-pr`: `ubuntu-latest` → `[self-hosted, Linux, X64]` |
| `preview-ready.yml` | `clear` + `mark` jobs: `ubuntu-latest` → `[self-hosted, Linux, X64]` |
| `docker-multiarch/action.yml` | Remove `cache-from: type=gha` + `cache-to: type=gha` (self-hosted runners have persistent storage) |

### Verification

Zero `ubuntu-latest` references remain. All `runs-on:` lines use either `[self-hosted, Linux, X64]` or `${{ matrix.runner }}`.
