### PR TITLE
fix: non-blocking SigNoz cache mutex

### DIFF
--- a/obs/signoz.go
+++ b/obs/signoz.go
@@ -62,11 +62,12 @@ func getNamespace() string {
 // hitting SigNoz on every SSE tick.
 func (c *SigNozClient) Fetch(ctx context.Context) (LiveData, error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if time.Since(c.cachedAt) < c.cacheTTL && len(c.cached.Services) > 0 {
-		return c.cached, nil
+		cached := c.cached
+		c.mu.Unlock()
+		return cached, nil
 	}
+	c.mu.Unlock()
 
 	fctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -108,15 +109,20 @@ func (c *SigNozClient) Fetch(ctx context.Context) (LiveData, error) {
 	services := BuildServices(results["cpu"], results, now)
 	hosts := BuildHosts(results)
 
-	c.cached = LiveData{
+	result := LiveData{
 		Hosts:         hosts,
 		Services:      services,
 		HasMetrics:    true,
 		Timestamp:     now.Unix(),
 		SelfNamespace: c.namespace,
 	}
+
+	c.mu.Lock()
+	c.cached = result
 	c.cachedAt = now
-	return c.cached, nil
+	c.mu.Unlock()
+
+	return result, nil
 }
 
 // ── v3 API types ──


### PR DESCRIPTION
Release mutex during HTTP call so concurrent requests don't queue behind 10s SigNoz fetches.

## Problem
Every request to `/` calls `liveClient.Fetch()` which holds a mutex for the entire 10s SigNoz HTTP call. This means all concurrent requests queue up, making every page load take 10s+.

## Fix
- Check cache under lock, release immediately if stale
- Do HTTP call without holding the lock  
- Re-acquire lock only to write the updated cache
- Prevents concurrent request serialization