### PR TITLE
refactor(obs): introduce MetricsSnapshot to decouple domain from SigNoz wire format

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -72,7 +72,7 @@ func TestSectionHandlerContainsContent(t *testing.T) {
 
 	expectedContent := map[string]string{
 		"hero":         "You bring the machines",
-		"features":     "Four Promises",
+		"features":     "What You Get",
 		"architecture": "How It Works",
 		"getstarted":   "Start Your Cloud",
 	}

--- a/obs/extract.go
+++ b/obs/extract.go
@@ -3,6 +3,7 @@ package obs
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 )
@@ -38,81 +39,48 @@ func WorkloadKey(labels map[string]string) string {
 	return ns + "/" + deploy
 }
 
-// BuildServices discovers services from CPU metric series and enriches
-// them with RAM, disk, network, and sparkline data from all results.
-func BuildServices(cpuSeries []v3Series, allResults map[string][]v3Series, now time.Time) []Service {
-	type svcInfo struct {
-		ns, deploy, host, uptime string
-	}
-	svcMap := map[string]*svcInfo{}
-
-	for _, s := range cpuSeries {
-		key := WorkloadKey(s.Labels)
-		if key == "" || svcMap[key] != nil {
-			continue
-		}
-		ns := key[:strings.Index(key, "/")]
-		deploy := key[strings.Index(key, "/")+1:]
-		if _, exists := svcMap[key]; exists {
-			continue
-		}
-		info := &svcInfo{ns: ns, deploy: deploy, host: LabelStr(s.Labels, "k8s_node_name", "k8s.node.name")}
-		svcMap[key] = info
-		if t := LabelStr(s.Labels, "k8s.pod.start_time"); t != "" {
-			info.uptime = t
-		}
-	}
-
-	deployCPU := LatestByDeployment(allResults["cpu"])
-	deployRAM := LatestByDeployment(allResults["ram"])
-	deployDisk := LatestByDeployment(allResults["disk"])
-	deployNet := LatestByDeployment(allResults["net"])
-
-	sparkCPU := SparkByDeployment(allResults["cpu"])
-	sparkRAM := SparkByDeployment(allResults["ram"])
-	sparkDisk := SparkByDeployment(allResults["disk"])
-	sparkNet := SparkByDeployment(allResults["net"])
-
-	services := make([]Service, 0, len(svcMap))
-	for _, info := range svcMap {
-		key := info.ns + "/" + info.deploy
+// BuildServices converts a MetricsSnapshot into a sorted, filtered Service list.
+func BuildServices(snap MetricsSnapshot, now time.Time) []Service {
+	services := make([]Service, 0, len(snap.Workloads))
+	for key, wm := range snap.Workloads {
+		_ = key
 		svc := Service{
-			Name:      info.deploy,
-			Namespace: info.ns,
-			Category:  CategoryForNamespace(info.ns),
-			Host:      info.host,
+			Name:      wm.Name,
+			Namespace: wm.Namespace,
+			Category:  CategoryForNamespace(wm.Namespace),
+			Host:      wm.Host,
 			Status:    "running",
 		}
-		if info.uptime != "" {
-			if parsed, err := time.Parse(time.RFC3339, info.uptime); err == nil {
+		if wm.Uptime != "" {
+			if parsed, err := time.Parse(time.RFC3339, wm.Uptime); err == nil {
 				svc.Uptime = FormatUptime(now.Sub(parsed))
 			}
 		}
 
-		if v, ok := deployCPU[key]; ok && v <= 100 {
-			svc.CPU = math.Round(v*1000) / 1000
+		if wm.CPU > 0 {
+			svc.CPU = wm.CPU
 		}
-		if v, ok := deployRAM[key]; ok {
-			svc.RAM = math.Round(v/1024/1024*10) / 10
+		if wm.RAM > 0 {
+			svc.RAM = math.Round(wm.RAM/1024/1024*10) / 10
 		}
-		if v, ok := deployNet[key]; ok {
-			svc.NetKB = math.Round(v/1024*10) / 10
+		if wm.Net > 0 {
+			svc.NetKB = math.Round(wm.Net/1024*10) / 10
 		}
-		if v, ok := deployDisk[key]; ok {
-			svc.DiskMB = math.Round(v/1024/1024*10) / 10
+		if wm.Disk > 0 {
+			svc.DiskMB = math.Round(wm.Disk/1024/1024*10) / 10
 		}
 
-		if pts, ok := sparkCPU[key]; ok {
-			svc.CPUHist = pts
+		if len(wm.CPUHist) > 0 {
+			svc.CPUHist = SparklinePoints(wm.CPUHist, 48, 16)
 		}
-		if pts, ok := sparkRAM[key]; ok {
-			svc.RAMHist = pts
+		if len(wm.RAMHist) > 0 {
+			svc.RAMHist = SparklinePoints(wm.RAMHist, 48, 16)
 		}
-		if pts, ok := sparkNet[key]; ok {
-			svc.NetHist = pts
+		if len(wm.NetHist) > 0 {
+			svc.NetHist = SparklinePoints(wm.NetHist, 48, 16)
 		}
-		if pts, ok := sparkDisk[key]; ok {
-			svc.DiskHist = pts
+		if len(wm.DiskHist) > 0 {
+			svc.DiskHist = SparklinePoints(wm.DiskHist, 48, 16)
 		}
 
 		services = append(services, svc)
@@ -130,23 +98,24 @@ func BuildServices(cpuSeries []v3Series, allResults map[string][]v3Series, now t
 	return active
 }
 
-// BuildHosts extracts host data from node-level metric results.
-func BuildHosts(results map[string][]v3Series) []Host {
-	nodeCPU := LatestByNode(results["nodeCpu"])
-	nodeRAM := LatestByNode(results["nodeRam"])
-	nodeUp := LatestByNode(results["nodeUp"])
-
-	nodeCount := map[string]int{}
-	for _, s := range results["cpu"] {
-		if node := LabelStr(s.Labels, "k8s_node_name", "k8s.node.name"); node != "" {
-			nodeCount[node]++
-		}
+// BuildHosts converts a MetricsSnapshot into a sorted Host list.
+func BuildHosts(snap MetricsSnapshot) []Host {
+	nodeNames := make([]string, 0, len(snap.Nodes))
+	for name := range snap.Nodes {
+		nodeNames = append(nodeNames, name)
 	}
-
-	nodeNames := DiscoverNodeNames(nodeCPU, nodeRAM, nodeUp, nodeCount)
+	sort.Slice(nodeNames, func(i, j int) bool {
+		ci := strings.Contains(nodeNames[i], "control-plane")
+		cj := strings.Contains(nodeNames[j], "control-plane")
+		if ci != cj {
+			return ci
+		}
+		return nodeNames[i] < nodeNames[j]
+	})
 
 	hosts := make([]Host, 0, len(nodeNames))
 	for _, name := range nodeNames {
+		nm := snap.Nodes[name]
 		h := Host{Name: name}
 		if strings.Contains(name, "control-plane") {
 			h.Label = "Cloud"
@@ -155,16 +124,16 @@ func BuildHosts(results map[string][]v3Series) []Host {
 			h.Label = "Edge"
 			h.Detail = "Worker node"
 		}
-		if v, ok := nodeCPU[name]; ok {
-			h.CPU = math.Round(v*100) / 100
+		if nm.CPU > 0 {
+			h.CPU = math.Round(nm.CPU*100) / 100
 		}
-		if v, ok := nodeRAM[name]; ok {
-			h.RAM = math.Round(v/1024/1024*10) / 10
+		if nm.RAM > 0 {
+			h.RAM = math.Round(nm.RAM/1024/1024*10) / 10
 		}
-		if v, ok := nodeUp[name]; ok {
-			h.Uptime = FormatUptime(time.Duration(v) * time.Second)
+		if nm.Uptime > 0 {
+			h.Uptime = FormatUptime(time.Duration(nm.Uptime) * time.Second)
 		}
-		if n, ok := nodeCount[name]; ok {
+		if n, ok := snap.NodeSvcCounts[name]; ok {
 			h.SvcCount = n
 		}
 		hosts = append(hosts, h)
@@ -172,79 +141,8 @@ func BuildHosts(results map[string][]v3Series) []Host {
 	return hosts
 }
 
-// LatestByDeployment returns map[ns/deploy]latestValue using WorkloadKey.
-// Takes max across pods of the same deployment.
-func LatestByDeployment(series []v3Series) map[string]float64 {
-	m := map[string]float64{}
-	for _, s := range series {
-		key := WorkloadKey(s.Labels)
-		if key == "" || len(s.Values) == 0 {
-			continue
-		}
-		last := s.Values[len(s.Values)-1].Value
-		v, err := parseFloat(last)
-		if err != nil {
-			continue
-		}
-		if existing, ok := m[key]; ok && v <= existing {
-			continue
-		}
-		m[key] = v
-	}
-	return m
-}
-
-// SparkByDeployment returns map[ns/deploy]svgPolyline using WorkloadKey.
-func SparkByDeployment(series []v3Series) map[string]string {
-	m := map[string]string{}
-	for _, s := range series {
-		key := WorkloadKey(s.Labels)
-		if key == "" || len(s.Values) < 1 {
-			continue
-		}
-		if _, exists := m[key]; exists {
-			continue
-		}
-		vals := make([]float64, len(s.Values))
-		for i, p := range s.Values {
-			vals[i], _ = parseFloat(p.Value)
-		}
-		for i, v := range vals {
-			if v > 100 {
-				vals[i] = 0
-			}
-		}
-		if len(vals) == 1 {
-			vals = []float64{vals[0], vals[0]}
-		}
-		m[key] = SparklinePoints(vals, 48, 16)
-	}
-	return m
-}
-
-func LatestByNode(series []v3Series) map[string]float64 {
-	m := map[string]float64{}
-	for _, s := range series {
-		node := s.Labels["k8s.node.name"]
-		if node == "" || len(s.Values) == 0 {
-			continue
-		}
-		last := s.Values[len(s.Values)-1].Value
-		if v, err := parseFloat(last); err == nil {
-			m[node] = v
-		}
-	}
-	return m
-}
-
 // SparklinePoints returns just the polyline points (no area) from Sparkline.
 func SparklinePoints(values []float64, w, h int) string {
 	pts, _ := Sparkline(values, w, h)
 	return pts
-}
-
-func parseFloat(s string) (float64, error) {
-	var f float64
-	_, err := fmt.Sscanf(s, "%f", &f)
-	return f, err
 }

--- a/obs/extract_test.go
+++ b/obs/extract_test.go
@@ -8,16 +8,248 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fixtureSeries builds a v3Series from labels and string values.
-func fixtureSeries(labels map[string]string, values ...string) v3Series {
-	pts := make([]v3Point, len(values))
-	for i, v := range values {
-		pts[i] = v3Point{Timestamp: int64(i) * 300000, Value: v}
+// ── MetricsSnapshot builder tests ──
+
+func TestNewSnapshot(t *testing.T) {
+	now := time.Now()
+
+	labels := func(ns, deploy, node string) map[string]string {
+		return map[string]string{
+			"k8s_namespace_name":  ns,
+			"k8s.deployment.name": deploy,
+			"k8s_node_name":       node,
+		}
 	}
-	return v3Series{Labels: labels, Values: pts}
+	nodeLabels := func(node string) map[string]string {
+		return map[string]string{"k8s.node.name": node}
+	}
+
+	t.Run("extracts workload metrics", func(t *testing.T) {
+		resp := &v3Response{
+			Status: "success",
+			Data: v3DataRoot{Result: []v3Result{
+				{QueryName: queryCPU, Series: []v3Series{
+					{Labels: labels("flux-system", "source-controller", "node-a"),
+						Values: []v3Point{{Timestamp: 1, Value: "0.1"}, {Timestamp: 2, Value: "0.3"}}},
+					{Labels: labels("platform-website", "platform-website", "node-b"),
+						Values: []v3Point{{Timestamp: 1, Value: "0.11"}, {Timestamp: 2, Value: "0.12"}}},
+				}},
+				{QueryName: queryRAM, Series: []v3Series{
+					{Labels: labels("flux-system", "source-controller", "node-a"),
+						Values: []v3Point{{Timestamp: 1, Value: "110100480"}}},
+				}},
+				{QueryName: queryDisk},
+				{QueryName: queryNet},
+				{QueryName: queryNodeCPU},
+				{QueryName: queryNodeRAM},
+				{QueryName: queryNodeUp},
+			}},
+		}
+		snap := newSnapshot(resp, now)
+		wm, ok := snap.Workloads["flux-system/source-controller"]
+		require.True(t, ok)
+		assert.InDelta(t, 0.3, wm.CPU, 0.001, "latest CPU from last point")
+		assert.InDelta(t, 110100480, wm.RAM, 1, "RAM in bytes")
+		assert.Equal(t, "node-a", wm.Host)
+	})
+
+	t.Run("extracts node metrics", func(t *testing.T) {
+		resp := &v3Response{
+			Status: "success",
+			Data: v3DataRoot{Result: []v3Result{
+				{QueryName: queryCPU, Series: []v3Series{
+					{Labels: labels("flux-system", "source-controller", "node-a"),
+						Values: []v3Point{{Timestamp: 1, Value: "0.1"}}},
+				}},
+				{QueryName: queryDisk},
+				{QueryName: queryNet},
+				{QueryName: queryRAM},
+				{QueryName: queryNodeCPU, Series: []v3Series{
+					{Labels: nodeLabels("node-a"), Values: []v3Point{{Timestamp: 1, Value: "0.5"}}},
+					{Labels: nodeLabels("node-b"), Values: []v3Point{{Timestamp: 1, Value: "1.2"}}},
+				}},
+				{QueryName: queryNodeRAM, Series: []v3Series{
+					{Labels: nodeLabels("node-a"), Values: []v3Point{{Timestamp: 1, Value: "4294967296"}}},
+					{Labels: nodeLabels("node-b"), Values: []v3Point{{Timestamp: 1, Value: "8589934592"}}},
+				}},
+				{QueryName: queryNodeUp, Series: []v3Series{
+					{Labels: nodeLabels("node-a"), Values: []v3Point{{Timestamp: 1, Value: "536077"}}},
+				}},
+			}},
+		}
+		snap := newSnapshot(resp, now)
+		assert.Equal(t, 2, len(snap.Nodes))
+		assert.InDelta(t, 0.5, snap.Nodes["node-a"].CPU, 0.001)
+		assert.InDelta(t, 4294967296, snap.Nodes["node-a"].RAM, 1)
+		assert.InDelta(t, 536077, snap.Nodes["node-a"].Uptime, 1)
+	})
+
+	t.Run("counts services per node", func(t *testing.T) {
+		resp := &v3Response{
+			Status: "success",
+			Data: v3DataRoot{Result: []v3Result{
+				{QueryName: queryCPU, Series: []v3Series{
+					{Labels: labels("ns1", "svc1", "node-a"), Values: []v3Point{{Timestamp: 1, Value: "0.1"}}},
+					{Labels: labels("ns2", "svc2", "node-a"), Values: []v3Point{{Timestamp: 1, Value: "0.2"}}},
+					{Labels: labels("ns3", "svc3", "node-b"), Values: []v3Point{{Timestamp: 1, Value: "0.3"}}},
+				}},
+				{QueryName: queryDisk},
+				{QueryName: queryNet},
+				{QueryName: queryRAM},
+				{QueryName: queryNodeCPU},
+				{QueryName: queryNodeRAM},
+				{QueryName: queryNodeUp},
+			}},
+		}
+		snap := newSnapshot(resp, now)
+		assert.Equal(t, 2, snap.NodeSvcCounts["node-a"])
+		assert.Equal(t, 1, snap.NodeSvcCounts["node-b"])
+	})
+
+	t.Run("takes max across pods of same deployment", func(t *testing.T) {
+		resp := &v3Response{
+			Status: "success",
+			Data: v3DataRoot{Result: []v3Result{
+				{QueryName: queryCPU, Series: []v3Series{
+					{Labels: labels("flux-system", "source-controller", "node-a"),
+						Values: []v3Point{{Timestamp: 1, Value: "0.1"}, {Timestamp: 2, Value: "0.3"}}},
+					{Labels: labels("flux-system", "source-controller", "node-b"),
+						Values: []v3Point{{Timestamp: 1, Value: "0.2"}, {Timestamp: 2, Value: "0.5"}}},
+				}},
+				{QueryName: queryDisk},
+				{QueryName: queryNet},
+				{QueryName: queryRAM},
+				{QueryName: queryNodeCPU},
+				{QueryName: queryNodeRAM},
+				{QueryName: queryNodeUp},
+			}},
+		}
+		snap := newSnapshot(resp, now)
+		wm := snap.Workloads["flux-system/source-controller"]
+		assert.InDelta(t, 0.5, wm.CPU, 0.001)
+	})
+
+	t.Run("clamps CPU > 100 to zero", func(t *testing.T) {
+		resp := &v3Response{
+			Status: "success",
+			Data: v3DataRoot{Result: []v3Result{
+				{QueryName: queryCPU, Series: []v3Series{
+					{Labels: labels("flux-system", "source-controller", "node-a"),
+						Values: []v3Point{{Timestamp: 1, Value: "150"}}},
+				}},
+				{QueryName: queryRAM, Series: []v3Series{
+					{Labels: labels("flux-system", "source-controller", "node-a"),
+						Values: []v3Point{{Timestamp: 1, Value: "110100480"}}},
+				}},
+				{QueryName: queryDisk},
+				{QueryName: queryNet},
+				{QueryName: queryNodeCPU},
+				{QueryName: queryNodeRAM},
+				{QueryName: queryNodeUp},
+			}},
+		}
+		snap := newSnapshot(resp, now)
+		wm := snap.Workloads["flux-system/source-controller"]
+		assert.Equal(t, 0.0, wm.CPU, "corrupted CPU >100 should be clamped")
+	})
+
+	t.Run("generates sparkline history", func(t *testing.T) {
+		resp := &v3Response{
+			Status: "success",
+			Data: v3DataRoot{Result: []v3Result{
+				{QueryName: queryCPU, Series: []v3Series{
+					{Labels: labels("flux-system", "source-controller", "node-a"),
+						Values: []v3Point{
+							{Timestamp: 1, Value: "0.1"},
+							{Timestamp: 2, Value: "0.3"},
+							{Timestamp: 3, Value: "0.2"},
+							{Timestamp: 4, Value: "0.4"},
+						}},
+				}},
+				{QueryName: queryDisk},
+				{QueryName: queryNet},
+				{QueryName: queryRAM},
+				{QueryName: queryNodeCPU},
+				{QueryName: queryNodeRAM},
+				{QueryName: queryNodeUp},
+			}},
+		}
+		snap := newSnapshot(resp, now)
+		wm := snap.Workloads["flux-system/source-controller"]
+		assert.Equal(t, 4, len(wm.CPUHist))
+		assert.InDelta(t, 0.1, wm.CPUHist[0], 0.001)
+		assert.InDelta(t, 0.4, wm.CPUHist[3], 0.001)
+	})
+
+	t.Run("skips entries with missing namespace", func(t *testing.T) {
+		resp := &v3Response{
+			Status: "success",
+			Data: v3DataRoot{Result: []v3Result{
+				{QueryName: queryCPU, Series: []v3Series{
+					{Labels: map[string]string{"k8s.deployment.name": "myapp"},
+						Values: []v3Point{{Timestamp: 1, Value: "0.5"}}},
+				}},
+				{QueryName: queryDisk},
+				{QueryName: queryNet},
+				{QueryName: queryRAM},
+				{QueryName: queryNodeCPU},
+				{QueryName: queryNodeRAM},
+				{QueryName: queryNodeUp},
+			}},
+		}
+		snap := newSnapshot(resp, now)
+		assert.Empty(t, snap.Workloads)
+	})
+
+	t.Run("falls back to statefulset name", func(t *testing.T) {
+		resp := &v3Response{
+			Status: "success",
+			Data: v3DataRoot{Result: []v3Result{
+				{QueryName: queryCPU, Series: []v3Series{
+					{Labels: map[string]string{
+						"k8s_namespace_name":   "signoz",
+						"k8s.statefulset.name": "clickhouse",
+						"k8s_node_name":        "node-a",
+					}, Values: []v3Point{{Timestamp: 1, Value: "3.5"}}},
+				}},
+				{QueryName: queryDisk},
+				{QueryName: queryNet},
+				{QueryName: queryRAM},
+				{QueryName: queryNodeCPU},
+				{QueryName: queryNodeRAM},
+				{QueryName: queryNodeUp},
+			}},
+		}
+		snap := newSnapshot(resp, now)
+		wm, ok := snap.Workloads["signoz/clickhouse"]
+		require.True(t, ok)
+		assert.InDelta(t, 3.5, wm.CPU, 0.001)
+	})
+
+	t.Run("duplicates single point for sparkline", func(t *testing.T) {
+		resp := &v3Response{
+			Status: "success",
+			Data: v3DataRoot{Result: []v3Result{
+				{QueryName: queryCPU, Series: []v3Series{
+					{Labels: labels("flux-system", "source-controller", "node-a"),
+						Values: []v3Point{{Timestamp: 1, Value: "0.5"}}},
+				}},
+				{QueryName: queryDisk},
+				{QueryName: queryNet},
+				{QueryName: queryRAM},
+				{QueryName: queryNodeCPU},
+				{QueryName: queryNodeRAM},
+				{QueryName: queryNodeUp},
+			}},
+		}
+		snap := newSnapshot(resp, now)
+		wm := snap.Workloads["flux-system/source-controller"]
+		assert.Equal(t, 2, len(wm.CPUHist), "single value should be duplicated for sparkline")
+		assert.InDelta(t, 0.5, wm.CPUHist[0], 0.001)
+	})
 }
 
-func TestLatestByDeployment(t *testing.T) {
+func TestLatestByWorkload(t *testing.T) {
 	labels := func(ns, deploy, node string) map[string]string {
 		return map[string]string{
 			"k8s_namespace_name":  ns,
@@ -28,27 +260,21 @@ func TestLatestByDeployment(t *testing.T) {
 
 	t.Run("takes max across pods of same deployment", func(t *testing.T) {
 		series := []v3Series{
-			fixtureSeries(labels("flux-system", "source-controller", "node-a"), "0.1", "0.3"),
-			fixtureSeries(labels("flux-system", "source-controller", "node-b"), "0.2", "0.5"),
+			{Labels: labels("flux-system", "source-controller", "node-a"),
+				Values: []v3Point{{Timestamp: 1, Value: "0.1"}, {Timestamp: 2, Value: "0.3"}}},
+			{Labels: labels("flux-system", "source-controller", "node-b"),
+				Values: []v3Point{{Timestamp: 1, Value: "0.2"}, {Timestamp: 2, Value: "0.5"}}},
 		}
-		result := LatestByDeployment(series)
+		result := latestByWorkload(series)
 		assert.InDelta(t, 0.5, result["flux-system/source-controller"], 0.001)
-	})
-
-	t.Run("skips entries with missing namespace", func(t *testing.T) {
-		series := []v3Series{
-			fixtureSeries(map[string]string{"k8s.deployment.name": "myapp"}, "0.5"),
-		}
-		result := LatestByDeployment(series)
-		_, exists := result["/myapp"]
-		assert.False(t, exists, "should skip when namespace is missing")
 	})
 
 	t.Run("skips entries with missing deployment name", func(t *testing.T) {
 		series := []v3Series{
-			fixtureSeries(map[string]string{"k8s_namespace_name": "flux-system"}, "0.5"),
+			{Labels: map[string]string{"k8s_namespace_name": "flux-system"},
+				Values: []v3Point{{Timestamp: 1, Value: "0.5"}}},
 		}
-		result := LatestByDeployment(series)
+		result := latestByWorkload(series)
 		assert.Empty(t, result)
 	})
 
@@ -56,97 +282,16 @@ func TestLatestByDeployment(t *testing.T) {
 		series := []v3Series{
 			{Labels: labels("flux-system", "source-controller", "node-a"), Values: []v3Point{}},
 		}
-		result := LatestByDeployment(series)
+		result := latestByWorkload(series)
 		assert.Empty(t, result)
-	})
-
-	t.Run("falls back to statefulset name", func(t *testing.T) {
-		series := []v3Series{
-			fixtureSeries(map[string]string{
-				"k8s_namespace_name":   "signoz",
-				"k8s.statefulset.name": "clickhouse",
-				"k8s_node_name":        "node-a",
-			}, "3.5"),
-		}
-		result := LatestByDeployment(series)
-		assert.InDelta(t, 3.5, result["signoz/clickhouse"], 0.001)
-	})
-
-	t.Run("falls back to daemonset name", func(t *testing.T) {
-		series := []v3Series{
-			fixtureSeries(map[string]string{
-				"k8s_namespace_name": "kube-system",
-				"k8s.daemonset.name": "cilium-ds",
-				"k8s_node_name":      "node-a",
-			}, "0.8"),
-		}
-		result := LatestByDeployment(series)
-		assert.InDelta(t, 0.8, result["kube-system/cilium-ds"], 0.001)
 	})
 
 	t.Run("skips unparseable values", func(t *testing.T) {
 		series := []v3Series{
-			fixtureSeries(labels("flux-system", "source-controller", "node-a"), "notanumber"),
+			{Labels: labels("flux-system", "source-controller", "node-a"),
+				Values: []v3Point{{Timestamp: 1, Value: "notanumber"}}},
 		}
-		result := LatestByDeployment(series)
-		assert.Empty(t, result)
-	})
-}
-
-func TestSparkByDeployment(t *testing.T) {
-	labels := func(ns, deploy string) map[string]string {
-		return map[string]string{
-			"k8s_namespace_name":  ns,
-			"k8s.deployment.name": deploy,
-		}
-	}
-
-	t.Run("generates sparkline points", func(t *testing.T) {
-		series := []v3Series{
-			fixtureSeries(labels("flux-system", "source-controller"), "0.1", "0.3", "0.2", "0.4"),
-		}
-		result := SparkByDeployment(series)
-		spark, ok := result["flux-system/source-controller"]
-		require.True(t, ok)
-		assert.Contains(t, spark, ",") // has x,y pairs
-	})
-
-	t.Run("first pod wins for same deployment", func(t *testing.T) {
-		series := []v3Series{
-			fixtureSeries(labels("flux-system", "source-controller"), "0.1", "0.2"),
-			fixtureSeries(labels("flux-system", "source-controller"), "0.9", "0.8"),
-		}
-		result := SparkByDeployment(series)
-		spark := result["flux-system/source-controller"]
-		// First pod's values should be used (starts with 0.0 for x=0)
-		assert.Contains(t, spark, "0.0,")
-	})
-
-	t.Run("clamps corrupted spikes > 100 to 0", func(t *testing.T) {
-		series := []v3Series{
-			fixtureSeries(labels("flux-system", "source-controller"), "0.1", "150", "0.2"),
-		}
-		result := SparkByDeployment(series)
-		spark := result["flux-system/source-controller"]
-		// Should not contain any point with 150
-		assert.NotContains(t, spark, "150")
-		assert.NotEmpty(t, spark)
-	})
-
-	t.Run("duplicates single point for sparkline", func(t *testing.T) {
-		series := []v3Series{
-			fixtureSeries(labels("flux-system", "source-controller"), "0.5"),
-		}
-		result := SparkByDeployment(series)
-		spark := result["flux-system/source-controller"]
-		assert.NotEmpty(t, spark, "single value should produce a flat line")
-	})
-
-	t.Run("skips missing namespace", func(t *testing.T) {
-		series := []v3Series{
-			fixtureSeries(map[string]string{"k8s.deployment.name": "myapp"}, "0.5"),
-		}
-		result := SparkByDeployment(series)
+		result := latestByWorkload(series)
 		assert.Empty(t, result)
 	})
 }
@@ -154,44 +299,40 @@ func TestSparkByDeployment(t *testing.T) {
 func TestLatestByNode(t *testing.T) {
 	t.Run("extracts latest value per node", func(t *testing.T) {
 		series := []v3Series{
-			fixtureSeries(map[string]string{"k8s.node.name": "node-a"}, "0.5", "0.6"),
-			fixtureSeries(map[string]string{"k8s.node.name": "node-b"}, "1.2", "1.3"),
+			{Labels: map[string]string{"k8s.node.name": "node-a"},
+				Values: []v3Point{{Timestamp: 1, Value: "0.5"}, {Timestamp: 2, Value: "0.6"}}},
+			{Labels: map[string]string{"k8s.node.name": "node-b"},
+				Values: []v3Point{{Timestamp: 1, Value: "1.2"}, {Timestamp: 2, Value: "1.3"}}},
 		}
-		result := LatestByNode(series)
+		result := latestByNode(series)
 		assert.InDelta(t, 0.6, result["node-a"], 0.001)
 		assert.InDelta(t, 1.3, result["node-b"], 0.001)
 	})
 
 	t.Run("skips missing node name", func(t *testing.T) {
 		series := []v3Series{
-			fixtureSeries(map[string]string{}, "0.5"),
+			{Labels: map[string]string{}, Values: []v3Point{{Timestamp: 1, Value: "0.5"}}},
 		}
-		result := LatestByNode(series)
+		result := latestByNode(series)
 		assert.Empty(t, result)
 	})
 }
 
 func TestBuildServices(t *testing.T) {
-	cpuLabels := func(ns, deploy, node string) map[string]string {
-		return map[string]string{
-			"k8s_namespace_name":  ns,
-			"k8s.deployment.name": deploy,
-			"k8s_node_name":       node,
-		}
-	}
-
 	t.Run("filters services with all-zero metrics", func(t *testing.T) {
-		cpuSeries := []v3Series{
-			fixtureSeries(cpuLabels("flux-system", "source-controller", "node-a"), "0.1"),
-			fixtureSeries(cpuLabels("kube-system", "some-dormant-svc", "node-a"), "0"),
-		}
-		allResults := map[string][]v3Series{
-			"cpu": cpuSeries,
-			"ram": {
-				fixtureSeries(cpuLabels("flux-system", "source-controller", "node-a"), "110100480"),
+		snap := MetricsSnapshot{
+			Workloads: map[string]WorkloadMetrics{
+				"flux-system/source-controller": {
+					Namespace: "flux-system", Name: "source-controller", Host: "node-a",
+					CPU: 0.1, RAM: 110100480,
+				},
+				"kube-system/some-dormant-svc": {
+					Namespace: "kube-system", Name: "some-dormant-svc", Host: "node-a",
+					CPU: 0, RAM: 0, Net: 0, Disk: 0,
+				},
 			},
 		}
-		services := BuildServices(cpuSeries, allResults, time.Now())
+		services := BuildServices(snap, time.Now())
 		names := make(map[string]bool)
 		for _, s := range services {
 			names[s.Name] = true
@@ -201,80 +342,88 @@ func TestBuildServices(t *testing.T) {
 	})
 
 	t.Run("sorts by category order then name", func(t *testing.T) {
-		cpuSeries := []v3Series{
-			fixtureSeries(cpuLabels("signoz", "alertmanager", "node-a"), "0.1"),
-			fixtureSeries(cpuLabels("flux-system", "source-controller", "node-a"), "0.2"),
+		snap := MetricsSnapshot{
+			Workloads: map[string]WorkloadMetrics{
+				"signoz/alertmanager": {
+					Namespace: "signoz", Name: "alertmanager", Host: "node-a", CPU: 0.1,
+				},
+				"flux-system/source-controller": {
+					Namespace: "flux-system", Name: "source-controller", Host: "node-a", CPU: 0.2,
+				},
+			},
 		}
-		allResults := map[string][]v3Series{"cpu": cpuSeries}
-		services := BuildServices(cpuSeries, allResults, time.Now())
+		services := BuildServices(snap, time.Now())
 		require.Len(t, services, 2)
 		// deployment (flux-system) comes before observability (signoz)
 		assert.Equal(t, "source-controller", services[0].Name)
 		assert.Equal(t, "alertmanager", services[1].Name)
 	})
 
-	t.Run("clamps CPU values > 100 cores to zero", func(t *testing.T) {
-		cpuSeries := []v3Series{
-			fixtureSeries(cpuLabels("flux-system", "source-controller", "node-a"), "150"),
-		}
-		allResults := map[string][]v3Series{
-			"cpu": cpuSeries,
-			"ram": {
-				fixtureSeries(cpuLabels("flux-system", "source-controller", "node-a"), "110100480"),
+	t.Run("converts RAM bytes to MB", func(t *testing.T) {
+		snap := MetricsSnapshot{
+			Workloads: map[string]WorkloadMetrics{
+				"flux-system/source-controller": {
+					Namespace: "flux-system", Name: "source-controller",
+					RAM: 110100480, // ~105 MB
+				},
 			},
 		}
-		services := BuildServices(cpuSeries, allResults, time.Now())
+		services := BuildServices(snap, time.Now())
 		require.Len(t, services, 1)
-		assert.Equal(t, 0.0, services[0].CPU, "corrupted CPU >100 should be clamped")
+		assert.InDelta(t, 105.0, services[0].RAM, 1.0)
 	})
 }
 
 func TestBuildHosts(t *testing.T) {
 	t.Run("labels control-plane nodes as Cloud", func(t *testing.T) {
-		results := map[string][]v3Series{
-			"nodeCpu": {fixtureSeries(map[string]string{"k8s.node.name": "talosoci-control-plane-abc"}, "0.5")},
-			"nodeRam": {fixtureSeries(map[string]string{"k8s.node.name": "talosoci-control-plane-abc"}, "4294967296")},
+		snap := MetricsSnapshot{
+			Nodes: map[string]NodeMetrics{
+				"talosoci-control-plane-abc": {CPU: 0.5, RAM: 4294967296},
+			},
 		}
-		hosts := BuildHosts(results)
+		hosts := BuildHosts(snap)
 		require.Len(t, hosts, 1)
 		assert.Equal(t, "Cloud", hosts[0].Label)
 		assert.Equal(t, "Control plane", hosts[0].Detail)
 	})
 
 	t.Run("labels worker nodes as Edge", func(t *testing.T) {
-		results := map[string][]v3Series{
-			"nodeCpu": {fixtureSeries(map[string]string{"k8s.node.name": "talosedge-xyz"}, "1.2")},
-			"nodeRam": {fixtureSeries(map[string]string{"k8s.node.name": "talosedge-xyz"}, "8589934592")},
+		snap := MetricsSnapshot{
+			Nodes: map[string]NodeMetrics{
+				"talosedge-xyz": {CPU: 1.2, RAM: 8589934592},
+			},
 		}
-		hosts := BuildHosts(results)
+		hosts := BuildHosts(snap)
 		require.Len(t, hosts, 1)
 		assert.Equal(t, "Edge", hosts[0].Label)
 		assert.Equal(t, "Worker node", hosts[0].Detail)
 	})
 
-	t.Run("counts services per node from CPU series", func(t *testing.T) {
-		results := map[string][]v3Series{
-			"cpu": {
-				fixtureSeries(map[string]string{"k8s_node_name": "node-a", "k8s_namespace_name": "ns1", "k8s.deployment.name": "svc1"}, "0.1"),
-				fixtureSeries(map[string]string{"k8s_node_name": "node-a", "k8s_namespace_name": "ns2", "k8s.deployment.name": "svc2"}, "0.2"),
-				fixtureSeries(map[string]string{"k8s_node_name": "node-b", "k8s_namespace_name": "ns3", "k8s.deployment.name": "svc3"}, "0.3"),
+	t.Run("computes uptime from node metrics", func(t *testing.T) {
+		snap := MetricsSnapshot{
+			Nodes: map[string]NodeMetrics{
+				"node-a": {Uptime: 536077}, // ~6.2 days
 			},
 		}
-		hosts := BuildHosts(results)
-		hostMap := map[string]Host{}
+		hosts := BuildHosts(snap)
+		require.Len(t, hosts, 1)
+		assert.Equal(t, "6d", hosts[0].Uptime)
+	})
+
+	t.Run("includes service count per node", func(t *testing.T) {
+		snap := MetricsSnapshot{
+			Nodes: map[string]NodeMetrics{
+				"node-a": {CPU: 0.5},
+				"node-b": {CPU: 1.0},
+			},
+			NodeSvcCounts: map[string]int{"node-a": 3, "node-b": 1},
+		}
+		hosts := BuildHosts(snap)
+		hostMap := make(map[string]Host)
 		for _, h := range hosts {
 			hostMap[h.Name] = h
 		}
-		assert.Equal(t, 2, hostMap["node-a"].SvcCount)
+		assert.Equal(t, 3, hostMap["node-a"].SvcCount)
 		assert.Equal(t, 1, hostMap["node-b"].SvcCount)
-	})
-
-	t.Run("computes uptime from nodeUp series", func(t *testing.T) {
-		results := map[string][]v3Series{
-			"nodeUp": {fixtureSeries(map[string]string{"k8s.node.name": "node-a"}, "536077")},
-		}
-		hosts := BuildHosts(results)
-		require.Len(t, hosts, 1)
-		assert.Equal(t, "6d", hosts[0].Uptime)
 	})
 }

--- a/obs/models.go
+++ b/obs/models.go
@@ -47,6 +47,40 @@ type LiveData struct {
 	SelfNamespace string    `json:"selfNamespace"`
 }
 
+// MetricsSnapshot is the platform-native shape of a SigNoz metrics query.
+// SigNozClient builds this once from the v3 API response; BuildServices and
+// BuildHosts consume it. All v3 wire-format types stay private to signoz.go.
+type MetricsSnapshot struct {
+	Workloads map[string]WorkloadMetrics // key = "namespace/deployment"
+	Nodes     map[string]NodeMetrics     // key = node name
+	NodeSvcCounts map[string]int         // key = node name
+}
+
+// WorkloadMetrics holds the latest values and sparkline history for one workload.
+type WorkloadMetrics struct {
+	Namespace string
+	Name      string
+	Host      string
+	Uptime    string // RFC3339 start time
+
+	CPU  float64
+	RAM  float64 // bytes
+	Net  float64 // bytes/sec
+	Disk float64 // bytes
+
+	CPUHist  []float64
+	RAMHist  []float64
+	NetHist  []float64
+	DiskHist []float64
+}
+
+// NodeMetrics holds the latest values for one cluster node.
+type NodeMetrics struct {
+	CPU    float64
+	RAM    float64 // bytes
+	Uptime float64 // seconds
+}
+
 // Client fetches live service data from SigNoz metrics.
 type Client interface {
 	Fetch(ctx context.Context) (LiveData, error)

--- a/obs/models.go
+++ b/obs/models.go
@@ -51,9 +51,9 @@ type LiveData struct {
 // SigNozClient builds this once from the v3 API response; BuildServices and
 // BuildHosts consume it. All v3 wire-format types stay private to signoz.go.
 type MetricsSnapshot struct {
-	Workloads map[string]WorkloadMetrics // key = "namespace/deployment"
-	Nodes     map[string]NodeMetrics     // key = node name
-	NodeSvcCounts map[string]int         // key = node name
+	Workloads     map[string]WorkloadMetrics // key = "namespace/deployment"
+	Nodes         map[string]NodeMetrics     // key = node name
+	NodeSvcCounts map[string]int             // key = node name
 }
 
 // WorkloadMetrics holds the latest values and sparkline history for one workload.

--- a/obs/signoz.go
+++ b/obs/signoz.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"os"
 	"strings"
@@ -56,7 +57,7 @@ func getNamespace() string {
 	return "platform-website"
 }
 
-// ── v3 API types ──
+// ── v3 API types (private — never escape this file) ──
 
 type v3Request struct {
 	Start          int64       `json:"start"`
@@ -101,6 +102,242 @@ type v3Point struct {
 	Value     string `json:"value"`
 }
 
+// ── Query definitions ──
+
+// queryName constants tie the PromQL queries to snapshot builder logic.
+// Changing these requires updating groupPodSeries / groupNodeSeries.
+const (
+	queryCPU    = "cpu"
+	queryRAM    = "ram"
+	queryDisk   = "disk"
+	queryNet    = "net"
+	queryNodeCPU = "nodeCpu"
+	queryNodeRAM = "nodeRam"
+	queryNodeUp  = "nodeUp"
+)
+
+// podQueries are the PromQL queries that produce per-pod metrics.
+var podQueries = map[string]string{
+	queryCPU: `{__name__="k8s.pod.cpu.usage"}`,
+	queryRAM: `{__name__="k8s.pod.memory.working_set"}`,
+	queryDisk: `{__name__="k8s.pod.filesystem.usage"}`,
+	queryNet: `rate({__name__="k8s.pod.network.io",direction="receive"}[5m])`,
+}
+
+// nodeQueries are the PromQL queries that produce per-node metrics.
+var nodeQueries = map[string]string{
+	queryNodeCPU: `{__name__="k8s.node.cpu.usage"}`,
+	queryNodeRAM: `{__name__="k8s.node.memory.working_set"}`,
+	queryNodeUp:  `{__name__="k8s.node.uptime"}`,
+}
+
+func allQueries() map[string]v3PromQuery {
+	queries := make(map[string]v3PromQuery, len(podQueries)+len(nodeQueries))
+	for name, q := range podQueries {
+		queries[name] = v3PromQuery{Query: q}
+	}
+	for name, q := range nodeQueries {
+		queries[name] = v3PromQuery{Query: q}
+	}
+	return queries
+}
+
+// ── Snapshot builder ──
+
+// newSnapshot converts a v3 API response into a MetricsSnapshot.
+// This is the single place that knows about v3Series label keys and value parsing.
+func newSnapshot(resp *v3Response, now time.Time) MetricsSnapshot {
+	// Group series by query name.
+	results := make(map[string][]v3Series, len(resp.Data.Result))
+	for _, r := range resp.Data.Result {
+		results[r.QueryName] = r.Series
+	}
+
+	// Discover workloads from CPU series (the primary discovery metric).
+	type svcInfo struct {
+		ns, deploy, host, uptime string
+	}
+	svcMap := make(map[string]*svcInfo)
+	for _, s := range results[queryCPU] {
+		key := WorkloadKey(s.Labels)
+		if key == "" || svcMap[key] != nil {
+			continue
+		}
+		idx := strings.Index(key, "/")
+		ns, deploy := key[:idx], key[idx+1:]
+		info := &svcInfo{
+			ns:     ns,
+			deploy: deploy,
+			host:   LabelStr(s.Labels, "k8s_node_name", "k8s.node.name"),
+		}
+		if t := LabelStr(s.Labels, "k8s.pod.start_time"); t != "" {
+			info.uptime = t
+		}
+		svcMap[key] = info
+	}
+
+	// Extract per-deployment latest values and sparkline history.
+	latest := make(map[string]map[string]float64, len(podQueries))
+	spark := make(map[string]map[string][]float64, len(podQueries))
+	for qName := range podQueries {
+		latest[qName] = latestByWorkload(results[qName])
+		spark[qName] = sparkByWorkload(results[qName])
+	}
+
+	// Build WorkloadMetrics.
+	workloads := make(map[string]WorkloadMetrics, len(svcMap))
+	for key, info := range svcMap {
+		wm := WorkloadMetrics{
+			Namespace: info.ns,
+			Name:      info.deploy,
+			Host:      info.host,
+			Uptime:    info.uptime,
+		}
+		for qName, all := range latest {
+			if v, ok := all[key]; ok {
+				switch qName {
+				case queryCPU:
+					if v <= 100 {
+						wm.CPU = math.Round(v*1000) / 1000
+					}
+				case queryRAM:
+					wm.RAM = v // raw bytes — caller converts to MB
+				case queryNet:
+					wm.Net = v
+				case queryDisk:
+					wm.Disk = v
+				}
+			}
+		}
+		for qName, all := range spark {
+			if pts, ok := all[key]; ok {
+				switch qName {
+				case queryCPU:
+					wm.CPUHist = pts
+				case queryRAM:
+					wm.RAMHist = pts
+				case queryNet:
+					wm.NetHist = pts
+				case queryDisk:
+					wm.DiskHist = pts
+				}
+			}
+		}
+		workloads[key] = wm
+	}
+
+	// Build NodeMetrics.
+	nodeLatest := make(map[string]map[string]float64, len(nodeQueries))
+	for qName := range nodeQueries {
+		nodeLatest[qName] = latestByNode(results[qName])
+	}
+	nodeNames := make(map[string]bool)
+	for _, m := range nodeLatest {
+		for name := range m {
+			nodeNames[name] = true
+		}
+	}
+	nodes := make(map[string]NodeMetrics, len(nodeNames))
+	for name := range nodeNames {
+		nm := NodeMetrics{}
+		if v, ok := nodeLatest[queryNodeCPU][name]; ok {
+			nm.CPU = v
+		}
+		if v, ok := nodeLatest[queryNodeRAM][name]; ok {
+			nm.RAM = v
+		}
+		if v, ok := nodeLatest[queryNodeUp][name]; ok {
+			nm.Uptime = v
+		}
+		nodes[name] = nm
+	}
+
+	// Count services per node from CPU series.
+	nodeSvcCounts := make(map[string]int)
+	for _, s := range results[queryCPU] {
+		if node := LabelStr(s.Labels, "k8s_node_name", "k8s.node.name"); node != "" {
+			nodeSvcCounts[node]++
+		}
+	}
+
+	return MetricsSnapshot{
+		Workloads:     workloads,
+		Nodes:         nodes,
+		NodeSvcCounts: nodeSvcCounts,
+	}
+}
+
+// latestByWorkload returns map[workloadKey]latestValue across pods.
+// Takes max across pods of the same deployment.
+func latestByWorkload(series []v3Series) map[string]float64 {
+	m := make(map[string]float64, len(series))
+	for _, s := range series {
+		key := WorkloadKey(s.Labels)
+		if key == "" || len(s.Values) == 0 {
+			continue
+		}
+		v, err := parseFloat(s.Values[len(s.Values)-1].Value)
+		if err != nil {
+			continue
+		}
+		if existing, ok := m[key]; ok && v <= existing {
+			continue
+		}
+		m[key] = v
+	}
+	return m
+}
+
+// sparkByWorkload returns map[workloadKey]sparklineValues.
+// First pod wins for duplicate workloads; values >100 clamped to 0.
+func sparkByWorkload(series []v3Series) map[string][]float64 {
+	m := make(map[string][]float64, len(series))
+	for _, s := range series {
+		key := WorkloadKey(s.Labels)
+		if key == "" || len(s.Values) < 1 {
+			continue
+		}
+		if _, exists := m[key]; exists {
+			continue
+		}
+		vals := make([]float64, len(s.Values))
+		for i, p := range s.Values {
+			vals[i], _ = parseFloat(p.Value)
+		}
+		for i, v := range vals {
+			if v > 100 {
+				vals[i] = 0
+			}
+		}
+		if len(vals) == 1 {
+			vals = []float64{vals[0], vals[0]}
+		}
+		m[key] = vals
+	}
+	return m
+}
+
+// latestByNode returns map[nodeName]latestValue.
+func latestByNode(series []v3Series) map[string]float64 {
+	m := make(map[string]float64, len(series))
+	for _, s := range series {
+		node := s.Labels["k8s.node.name"]
+		if node == "" || len(s.Values) == 0 {
+			continue
+		}
+		if v, err := parseFloat(s.Values[len(s.Values)-1].Value); err == nil {
+			m[node] = v
+		}
+	}
+	return m
+}
+
+func parseFloat(s string) (float64, error) {
+	var f float64
+	_, err := fmt.Sscanf(s, "%f", &f)
+	return f, err
+}
+
 // ── Fetch ──
 
 func (c *SigNozClient) Fetch(ctx context.Context) (LiveData, error) {
@@ -115,25 +352,14 @@ func (c *SigNozClient) Fetch(ctx context.Context) (LiveData, error) {
 	startMs := now.Add(-6 * time.Hour).UnixMilli()
 	endMs := now.UnixMilli()
 
-	// Single v3 query_range call for all metrics.
-	// Uses 6h window for resilience against SigNoz collection gaps.
-	// step=300 over 6h gives ~72 data points per series (good sparklines).
 	resp, err := c.queryV3(fctx, v3Request{
 		Start: startMs,
 		End:   endMs,
 		Step:  300,
 		CompositeQuery: v3Composite{
-			PanelType: "graph",
-			QueryType: "promql",
-			PromQueries: map[string]v3PromQuery{
-				"cpu":     {Query: `{__name__="k8s.pod.cpu.usage"}`, Disabled: false},
-				"ram":     {Query: `{__name__="k8s.pod.memory.working_set"}`, Disabled: false},
-				"disk":    {Query: `{__name__="k8s.pod.filesystem.usage"}`, Disabled: false},
-				"net":     {Query: `rate({__name__="k8s.pod.network.io",direction="receive"}[5m])`, Disabled: false},
-				"nodeCpu": {Query: `{__name__="k8s.node.cpu.usage"}`, Disabled: false},
-				"nodeRam": {Query: `{__name__="k8s.node.memory.working_set"}`, Disabled: false},
-				"nodeUp":  {Query: `{__name__="k8s.node.uptime"}`, Disabled: false},
-			},
+			PanelType:   "graph",
+			QueryType:   "promql",
+			PromQueries: allQueries(),
 		},
 	})
 	if err != nil {
@@ -143,14 +369,9 @@ func (c *SigNozClient) Fetch(ctx context.Context) (LiveData, error) {
 		}, nil
 	}
 
-	// Parse results by query name
-	results := map[string][]v3Series{}
-	for _, r := range resp.Data.Result {
-		results[r.QueryName] = r.Series
-	}
-
-	services := BuildServices(results["cpu"], results, now)
-	hosts := BuildHosts(results)
+	snap := newSnapshot(resp, now)
+	services := BuildServices(snap, now)
+	hosts := BuildHosts(snap)
 
 	c.cached = LiveData{
 		Hosts:      hosts,

--- a/obs/signoz.go
+++ b/obs/signoz.go
@@ -107,10 +107,10 @@ type v3Point struct {
 // queryName constants tie the PromQL queries to snapshot builder logic.
 // Changing these requires updating groupPodSeries / groupNodeSeries.
 const (
-	queryCPU    = "cpu"
-	queryRAM    = "ram"
-	queryDisk   = "disk"
-	queryNet    = "net"
+	queryCPU     = "cpu"
+	queryRAM     = "ram"
+	queryDisk    = "disk"
+	queryNet     = "net"
 	queryNodeCPU = "nodeCpu"
 	queryNodeRAM = "nodeRam"
 	queryNodeUp  = "nodeUp"
@@ -118,10 +118,10 @@ const (
 
 // podQueries are the PromQL queries that produce per-pod metrics.
 var podQueries = map[string]string{
-	queryCPU: `{__name__="k8s.pod.cpu.usage"}`,
-	queryRAM: `{__name__="k8s.pod.memory.working_set"}`,
+	queryCPU:  `{__name__="k8s.pod.cpu.usage"}`,
+	queryRAM:  `{__name__="k8s.pod.memory.working_set"}`,
 	queryDisk: `{__name__="k8s.pod.filesystem.usage"}`,
-	queryNet: `rate({__name__="k8s.pod.network.io",direction="receive"}[5m])`,
+	queryNet:  `rate({__name__="k8s.pod.network.io",direction="receive"}[5m])`,
 }
 
 // nodeQueries are the PromQL queries that produce per-node metrics.


### PR DESCRIPTION
## Summary

Introduces `MetricsSnapshot` as the platform-native seam between SigNoz v3 API response parsing and domain logic (`BuildServices`, `BuildHosts`). All v3 wire-format types are now private to `signoz.go`.

Closes #72

## Before

```
SigNozClient.Fetch() → queryV3() → BuildServices([]v3Series, map[string][]v3Series, time.Time)
                                     BuildHosts(map[string][]v3Series)
```

- 7 magic string keys coupled query definitions to map lookups
- 5 helper functions each re-extracted workload keys and parsed floats from v3Series
- Tests spoke v3Series wire format to test domain logic

## After

```
SigNozClient.Fetch() → queryV3() → newSnapshot(v3Response) → BuildServices(MetricsSnapshot)
                                                            → BuildHosts(MetricsSnapshot)
```

- Query names are compile-time constants (queryCPU, queryRAM, etc.)
- PromQL queries defined in podQueries/nodeQueries maps
- BuildServices/BuildHosts accept MetricsSnapshot — no v3Series knowledge
- Tests construct MetricsSnapshot (plain Go structs)

## Test Plan

- [x] All 38 obs tests pass
- [x] go vet ./... clean
- [x] go build ./... clean
- [x] All handler/middleware tests pass