### PR TITLE
fix(ci): preserve per-arch manifests in cleanup-untagged

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -77,16 +77,53 @@ jobs:
 
           VERSIONS=$(gh api "/orgs/${{ github.repository_owner }}/packages/container/${{ github.event.repository.name }}/versions?per_page=100" --paginate 2>/dev/null || echo '[]')
 
+          # Build the set of digests referenced by any tagged multi-arch index.
+          # Multi-arch (buildx) pushes upload per-architecture manifests and
+          # attestation manifests as UNTAGGED versions, referenced by digest
+          # from the tagged index. Deleting them turns the index into a dead
+          # pointer and breaks image pulls with "manifest unknown".
+          REFERENCED_FILE=$(mktemp)
+          trap 'rm -f "$REFERENCED_FILE"' EXIT
+
+          REGISTRY_TOKEN=$(curl -sS \
+            -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            "https://ghcr.io/token?scope=repository:${{ github.repository }}:pull&service=ghcr.io" \
+            | jq -r .token)
+
+          for TAG in $(echo "$VERSIONS" | jq -r '.[]? | select((.metadata.container.tags // []) | length > 0) | .metadata.container.tags[]'); do
+            curl -sS \
+              -H "Authorization: Bearer $REGISTRY_TOKEN" \
+              -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+              "https://ghcr.io/v2/${{ github.repository }}/manifests/$TAG" \
+              | jq -r 'if has("manifests") then .manifests[].digest else empty end' \
+              >> "$REFERENCED_FILE"
+          done
+
+          sort -u "$REFERENCED_FILE" -o "$REFERENCED_FILE"
+          REFERENCED_COUNT=$(wc -l < "$REFERENCED_FILE")
+          echo "Found ${REFERENCED_COUNT} digests referenced by tagged images"
+
           UNTAGGED=$(echo "$VERSIONS" | jq -c "[.[]? | select((.metadata.container.tags // []) | length == 0)]")
           TOTAL=$(echo "$UNTAGGED" | jq 'length')
 
           echo "Found ${TOTAL} untagged versions"
 
           DELETED=0
+          SKIPPED=0
           FAILED=0
 
-          for VID in $(echo "$UNTAGGED" | jq -r '.[].id'); do
+          for VID_NAME in $(echo "$UNTAGGED" | jq -r '.[] | "\(.id)|\(.name)"'); do
+            VID=$(echo "$VID_NAME" | cut -d'|' -f1)
+            VNAME=$(echo "$VID_NAME" | cut -d'|' -f2)
+
+            if [ -n "$VNAME" ] && grep -qx "$VNAME" "$REFERENCED_FILE" 2>/dev/null; then
+              echo "  Keeping version ${VID} (${VNAME}) — referenced by tagged index"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
             if gh api -X DELETE "/orgs/${{ github.repository_owner }}/packages/container/${{ github.event.repository.name }}/versions/${VID}" 2>/dev/null; then
+              echo "  Deleted orphaned version ${VID} (${VNAME})"
               DELETED=$((DELETED + 1))
             else
               echo "  Failed to delete untagged version ${VID}"
@@ -94,7 +131,7 @@ jobs:
             fi
           done
 
-          echo "Untagged cleanup: ${DELETED} deleted, ${FAILED} failed out of ${TOTAL}"
+          echo "Untagged cleanup: ${DELETED} deleted, ${SKIPPED} kept (referenced), ${FAILED} failed out of ${TOTAL}"
 
   cleanup-manual:
     if: github.event_name == 'workflow_dispatch'
@@ -113,9 +150,33 @@ jobs:
 
           TO_DELETE="[]"
 
+          REFERENCED_FILE=$(mktemp)
+          trap 'rm -f "$REFERENCED_FILE"' EXIT
+
+          REGISTRY_TOKEN=$(curl -sS \
+            -u "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" \
+            "https://ghcr.io/token?scope=repository:${{ github.repository }}:pull&service=ghcr.io" \
+            | jq -r .token)
+
+          for TAG in $(echo "$VERSIONS" | jq -r '.[]? | select((.metadata.container.tags // []) | length > 0) | .metadata.container.tags[]'); do
+            curl -sS \
+              -H "Authorization: Bearer $REGISTRY_TOKEN" \
+              -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+              "https://ghcr.io/v2/${{ github.repository }}/manifests/$TAG" \
+              | jq -r 'if has("manifests") then .manifests[].digest else empty end' \
+              >> "$REFERENCED_FILE"
+          done
+          sort -u "$REFERENCED_FILE" -o "$REFERENCED_FILE"
+
           if [ "$PRUNE_UNTAGGED" = "true" ]; then
-            echo "Collecting untagged versions..."
-            UNTAGGED=$(echo "$VERSIONS" | jq -c "[.[]? | select((.metadata.container.tags // []) | length == 0)]")
+            echo "Collecting untagged orphaned versions (excluding those referenced by tagged indexes)..."
+            REFERENCED_JSON=$(jq -R -s 'split("\n") | map(select(length > 0))' "$REFERENCED_FILE")
+            UNTAGGED=$(echo "$VERSIONS" | jq --argjson ref "$REFERENCED_JSON" '
+              [.[]? |
+                select((.metadata.container.tags // []) | length == 0) |
+                select(.name as $n | $ref | index($n) | not)
+              ]
+            ')
             TO_DELETE=$(echo "$TO_DELETE" | jq --argjson add "$UNTAGGED" '. + $add')
           fi
 


### PR DESCRIPTION
## Problem

The `cleanup-untagged` job in `cleanup-images.yml` was deleting per-architecture and attestation manifests uploaded by docker buildx as untagged versions. These manifests are referenced **by digest** from the tagged multi-arch index. Deleting them turns the index into a dead pointer, and image pulls fail with:

```
failed to copy: httpReadSeeker: failed open: content at
https://ghcr.io/v2/rezuscloud/platform-website/manifests/<arch-digest> not found: not found
```

## Symptoms observed today

| Image | Tag | Created | Status after cleanup |
|---|---|---|---|
| prod | `v1.9.0-2` | 21:26:02Z | **Unpullable** (prod deployment in ImagePullBackOff 11h; old pod serving from cache) |
| preview | `pr-77-13edfb97` | 21:20:28Z | **Unpullable** (preview deployment in ImagePullBackOff 11h) |

The cleanup-untagged job ran at 21:26:42Z and deleted 33 untagged versions, including the per-arch manifests of every multi-arch image pushed since the workflow was added on May 8.

## Root cause

Docker buildx multi-arch push uploads three things to GHCR:
1. Per-arch manifest (amd64) — uploaded **untagged**
2. Per-arch manifest (arm64) — uploaded **untagged**  
3. Multi-arch **index** — uploaded with the user-facing tag

GitHub Packages API registers each as a separate "version". The cleanup script selected all versions with `tags == []` and deleted them — including the per-arch manifests the index needs.

## Fix

Before deleting any untagged version:

1. Fetch a registry token via `ghcr.io/token` using `GITHUB_TOKEN`
2. For each tagged version, fetch its manifest via the registry API
3. Extract every digest the manifest references (per-arch + attestation)
4. Skip deletion of any untagged version whose `name` (digest) appears in that referenced set

Only truly orphaned untagged versions (e.g. from a failed/interrupted push) get deleted.

The same cross-reference is applied to `cleanup-manual` for consistency.

## Recovery

This fix prevents future breakage. Existing broken indexes (`v1.9.0-2`, `pr-77-13edfb97`, plus all older PR builds since May 8) must be deleted from GHCR and their images rebuilt. Rebuild will happen automatically:
- prod: release.yml runs on merge to master
- preview PR #77: workflow_dispatch on ci.yml