### PR TITLE
fix(release): fetch docs before goreleaser docker build

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -8,6 +8,7 @@ before:
     - templ generate
     - npm ci
     - npx @tailwindcss/cli -i input.css -o assets/styles.css --minify
+    - bash scripts/fetch-docs.sh
 
 builds:
   - env: [CGO_ENABLED=0]


### PR DESCRIPTION
## Problem

`v1.9.0-6` (and -4, -5) release failed with:

```
⨯ release failed after 29s
   error=docker images (v2): failed to publish artifacts:
     failed to copy extra file 'docs/external':
     failed to copy docs/external to /tmp/.../docs/external:
     lstat docs/external: no such file or directory
```

The release pipeline was silently broken since the docs external-fetch landed. The Dockerfile.release and goreleaser config both reference `docs/external/`, but that directory is gitignored (populated at CI time by `scripts/fetch-docs.sh`). The CI workflow runs that script but the release workflow does not.

Production is stuck on `v1.9.0-3`.

## Fix

Add `bash scripts/fetch-docs.sh` to the goreleaser `before:` hooks, after `templ generate` and `npm ci` (it needs no dependencies beyond `gh` CLI, which is pre-installed on the runner and auto-detects `GITHUB_TOKEN` from env).

## Verification

- [x] `gh auth status` auto-detects `GITHUB_TOKEN` env (verified locally)
- [x] `scripts/fetch-docs.sh` runs successfully with only `GITHUB_TOKEN` env (verified locally)
- [ ] Release workflow runs end-to-end on merge