### PR TITLE
fix(release): pass NODE_AUTH_TOKEN to GoReleaser for npm fetch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
           args: release --clean --config .github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   snapshot:
     name: Snapshot Build
@@ -209,4 +210,5 @@ jobs:
           args: release --snapshot --clean --config .github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: v${{ steps.gitversion.outputs.semVer }}


### PR DESCRIPTION
## Problem

```
npm error 401 Unauthorized - GET https://npm.pkg.github.com/download/
  @rezuscloud/design-system/1.0.0/... - unauthenticated: User cannot
  be authenticated with the token provided.
```

The release job runs `npm ci` inside goreleaser before hooks (to fetch `@rezuscloud/design-system` from GitHub Packages). The repo `.npmrc` references `${NODE_AUTH_TOKEN}` but the `Run GoReleaser` step only sets `GITHUB_TOKEN`. On self-hosted runners with cached `node_modules` this happened to work; on a clean checkout (or after a `package-lock.json` change) it fails.

Blocking: production has been stuck on `v1.9.0-3` for ~12 hours because the previous fix (`#83`) exposed this next layer.

## Fix

Set `NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` in the env for both `Run GoReleaser` and `Run GoReleaser (snapshot)` steps. The auto-generated `GITHUB_TOKEN` has `read:packages` scope for the installing user.

## Verification

- [x] `GITHUB_TOKEN` is documented to have `read:packages` scope ([docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication))
- [x] `@rezuscloud/design-system` package is published from a public-visibility repo in the same org
- [ ] Release workflow runs end-to-end on merge