### PR TITLE
fix(cache): serve HTML with Cache-Control: no-cache

### DIFF
--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -13,6 +13,7 @@ func ErrorHandler(c *fiber.Ctx, err error) error {
 
 	c.Status(code)
 	c.Set("Content-Type", "text/html; charset=utf-8")
+	c.Set("Cache-Control", "no-cache")
 
 	switch code {
 	case fiber.StatusNotFound:

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -27,6 +27,37 @@ func TestHomeHandler(t *testing.T) {
 	assert.Equal(t, "text/html; charset=utf-8", resp.Header.Get("Content-Type"))
 }
 
+func TestHTMLResponsesAreNeverCached(t *testing.T) {
+	// HTML must always revalidate against the origin so a browser never serves
+	// a pre-deploy page (no ETag/Last-Modified is sent, so no-cache == fresh).
+	// See fix/html-no-cache; regression guard for the stale-page bug.
+	app := setupApp()
+
+	cases := []struct {
+		name string
+		path string
+	}{
+		{"home", "/"},
+		{"section-hero", "/sections/hero"},
+		{"not-found", "/this-route-does-not-exist"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tc.path, nil)
+			resp, err := app.Test(req, -1)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			ct := resp.Header.Get("Content-Type")
+			require.True(t, strings.HasPrefix(ct, "text/html"),
+				"%s: expected HTML, got %q", tc.name, ct)
+			assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"),
+				"%s: HTML must not be cached across deploys", tc.name)
+		})
+	}
+}
+
 func TestHomeHandlerContainsExpectedContent(t *testing.T) {
 	app := setupApp()
 

--- a/handlers/pages.go
+++ b/handlers/pages.go
@@ -58,8 +58,14 @@ func SetLiveClient(c obs.Client) {
 }
 
 // Render adapts a templ.Component to a Fiber response.
+//
+// HTML responses use Cache-Control: no-cache so browsers always revalidate
+// against the origin after a deploy. Without it (and with no ETag/Last-Modified
+// on these responses) a browser can hold a pre-deploy page across deploys.
+// Static assets keep their own long cache via app.Static in main.go.
 func render(c *fiber.Ctx, component templ.Component) error {
 	c.Set("Content-Type", "text/html; charset=utf-8")
+	c.Set("Cache-Control", "no-cache")
 	return component.Render(c.Context(), c.Response().BodyWriter())
 }
 


### PR DESCRIPTION
## Problem

After PR #86 merged, prod kept serving the pre-rollout page (`v1.9.0-8`) for ~22 min, and a cached copy of that older Live section persisted in browsers. Root cause: HTML responses carried **no cache directives**, and the server sends no `ETag`/`Last-Modified`, so a browser could hold a pre-deploy page across deploys.

## Fix

Add `Cache-Control: no-cache` to both HTML render paths:

- `render()` (`handlers/pages.go`) — covers Home, section partials, docs pages
- `ErrorHandler` (`handlers/errors.go`) — covers 404/500

`no-cache` means "you may store, but must revalidate before use". Since these responses send no validators, every navigation fetches fresh content — a browser can never again serve a pre-deploy page.

## Scope

- **HTML responses**: now `no-cache` (always revalidate)
- **Static assets**: untouched — CSS/JS keep 24h (`app.Static` MaxAge 86400), fonts keep 1y (MaxAge 31536000)

## Regression test

`TestHTMLResponsesAreNeverCached` asserts `Cache-Control: no-cache` on:
- `/` (Home)
- `/sections/hero` (section partial)
- `/this-route-does-not-exist` (404 error page)

Covers both edited code paths.

## Verification

```
go build ./...        # OK
go vet ./handlers/    # clean
go test ./...         # all pass
```

## Test plan
- [x] New regression test passes
- [x] Existing handler tests pass
- [x] `gofmt` clean
- [ ] Preview: verify `curl -sI .../` shows `cache-control: no-cache` and `.../assets/styles.css` keeps `max-age=86400`