### PR TITLE
docs(design): reconcile DESIGN.md with shipped product (P2)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,7 +31,7 @@ colors:
 typography:
   display:
     fontFamily: "Silkscreen, system-ui, sans-serif"
-    fontWeight: 800
+    fontWeight: 700
     fontSize: "clamp(3rem, 8vw, 6rem)"
     lineHeight: 0.88
     letterSpacing: "-0.05em"
@@ -150,7 +150,7 @@ For the brand strategy, storytelling context, and anti-references behind this vi
 - CRT overlay: scanline pattern at 2px intervals with slow vertical scroll animation.
 - Bitmap typography: Silkscreen for headings, labels, and nav. system-ui for body. VT323 for terminals.
 - All animations respect `prefers-reduced-motion`. FOUC prevention via inline script.
-- 5 sections: Hero, Architecture, Live Platform, Features, Get Started.
+- 5 composed home sections: Hero, Architecture, Live Platform, Features, Get Started (see views/pages/home.templ). 4 further section templates (Challenge, Networking, Comparison, UseCases) exist as standalone HTMX partials served at /sections/<name> and are registered in handlers/pages.go, but are not part of the home narrative.
 - Live Platform: collapsible category-first grid with SSE real-time metrics. Self-namespace category auto-expands.
 - Progressive disclosure: Live section categories collapsed by default, expand on click.
 
@@ -207,7 +207,7 @@ Two complete palettes, each with warm-tinted neutrals and one saturated accent. 
 
 ### Hierarchy
 
-- **Display** (800 weight, text-5xl to text-8xl, leading-[0.88], tracking-tighter): Hero headline only. "YOUR PERSONAL CLOUD" as the single most prominent element on the page.
+- **Display** (700 weight, text-5xl to text-8xl, leading-[0.88], tracking-tighter): Hero headline only. "YOUR PERSONAL CLOUD" as the single most prominent element on the page.
 - **Headline** (700 weight, text-2xl to text-4xl, tracking-tight): Section headings ("How It Works", "Live Platform", "What You Get", "Start Your Cloud", "Your Machine Room"). Centered for all sections except hero.
 - **Title** (700 weight, text-lg, leading-snug): Feature names ("No Platform Tax", "Private by Design"), sub-section headings.
 - **Body** (400 weight, text-sm to text-lg, leading-relaxed): Paragraph copy, descriptions, feature details. Max line length 65-75ch.
@@ -247,7 +247,7 @@ NeXT mode uses a 2px 3D bevel system. The bevels simulate the chunky, period-aut
 
 ### Navigation
 
-Fixed top bar, z-50. `surface-strong` (light) / `next-dark` (dark) background. 1px bottom border (`rule` / `next-mid`). Logo: icon square (32x32) + "Rezus" in ink/next-white + "Cloud" in accent-gold/next-teal. Desktop links: Silkscreen label weight, uppercase, 4 items (Home, Architecture, Features, Get Started). Active state: pill background (paper/next-light). Hover: surface/next-mid background. Mobile: hamburger menu with slide-down panel (200ms ease-out). IntersectionObserver tracks active section via scroll position.
+Fixed top bar, z-50. `surface-strong` (light) / `next-dark` (dark) background. 1px bottom border (`rule` / `next-mid`). Logo: icon square (32x32) + "Rezus" in ink/next-white + "Cloud" in accent-gold/next-teal. Desktop links: Silkscreen label weight, uppercase, 5 items (Home, Architecture, Features, Get Started, Docs). Active state: pill background (paper/next-light). Hover: surface/next-mid background. Mobile: hamburger menu with slide-down panel (200ms ease-out). IntersectionObserver tracks active section via scroll position.
 
 ### CTA Button
 


### PR DESCRIPTION
Closes #91.

## Problem
DESIGN.md had drifted from the code, so it could no longer govern the design:
- Display typography role claimed \`fontWeight: 800\`; Silkscreen only ships 400/**700** and 700 is what renders.
- Nav claimed **4 items**; the shipped nav has **5** (+ Docs).
- The "5 sections" claim is accurate for the *composed home page* but ignored the 4 standalone section templates that exist as HTMX partials.

## Fix (docs only, no behavior change)
- Display \`fontWeight: 800\` → \`700\` (frontmatter + hierarchy prose).
- Nav \`4 items\` → \`5 items (Home, Architecture, Features, Get Started, Docs)\`.
- Clarified the section count: **5 composed home sections** (Hero, Architecture, Live Platform, Features, Get Started, per \`views/pages/home.templ\`) **+ 4 standalone HTMX partials** (Challenge, Networking, Comparison, UseCases) served at \`/sections/<name>\`, registered in \`handlers/pages.go\` but not part of the home narrative.

Verified against code: \`home.templ\` composes 5; \`sectionMap\` registers 9 (5 + 4).

## Out of scope
Whether to **re-integrate** the 4 standalone partials into the home narrative or **delete** them is a separate product decision (flagged in #91), not a doc fix.

## Test plan
- [ ] Read-through: DESIGN.md now matches what ships.