### PR TITLE
fix(a11y): NeXT terminal title bar clears WCAG AA (#95)

### DIFF
--- a/input.css
+++ b/input.css
@@ -234,6 +234,15 @@
 	background-size: 24px 24px;
 }
 
+/* NeXT mode: drop the Mac cream barber-pole so the dual-era contract holds.
+   The base rule paints an opaque gradient via the `background` shorthand,
+   which hides the templ-level `dark:bg-next-mid`. Restoring a flat next-mid
+   title bar also fixes the title-label contrast (next-subtle-text on
+   next-mid >= 4.5:1). See issue #95. */
+.dark .mac-title-bar-animated {
+	background: var(--color-next-mid);
+}
+
 /* ===== Mac custom cursor (retro arrow) ===== */
 
 .mac-cursor {


### PR DESCRIPTION
Closes #95.

## What was actually wrong (diagnosis corrected)

Issue #95 was **inverted** about which mode fails. Verified by chromedp pixel sampling + OKLCH→sRGB contrast math:

- **Light mode passed** (~7.8:1). The title bar is `.mac-title-bar-animated`, an opaque Mac cream barber-pole (oklch 82-92%), not `bg-next-black`. `ink-muted` on cream is fine.
- **Dark mode failed** (~1.3:1), but the cause is **not** `ink-muted` on the dark terminal body. `.mac-title-bar-animated` sets the cream gradient via the `background` shorthand with **no dark-scoped override**. `background-image` paints above `background-color`, so the templ-level `dark:bg-next-mid` was completely hidden — the dark title bar also rendered cream, with light `next-subtle-text` (L0.78) on it.

This is a missing `.dark .mac-title-bar-animated` override, not a text-token problem. (The issue's suggested "likely fix", swapping to a cream text token, would have broken light mode while leaving dark mode broken.)

## Fix

One CSS rule, following the established `.dark .foo` convention in `input.css`:

```css
.dark .mac-title-bar-animated {
    background: var(--color-next-mid);
}
```

Drops the Mac gradient in NeXT mode so the flat `next-mid` title bar + `next-raised` bevel render. No new tokens; the existing text tokens already pass once the correct background shows. Fixes all three terminals (hero, getstarted, ai) since they share the class.

## Verification

| Mode | text on bg | contrast | result |
|------|-----------|----------|--------|
| Light | `ink-muted` (L0.30) on cream barber-pole (L0.82-92%) | **7.8–10.8:1** | PASS (unchanged) |
| Dark | `next-subtle-text` (L0.78) on `next-mid` (L0.34) | **5.88:1** | PASS (was ~1.3:1) |

Measured via chromedp pixel sampling (painted bg) + analytical OKLCH→sRGB luminance. `templ fmt` / `gofmt` / `go vet` clean; `go test ./...` green.

## Scope

9 lines in `input.css` only. `assets/styles.css` is generated (gitignored), rebuilt at release.