### PR TITLE
fix(obs): fallback surfaces "unavailable" instead of a phantom cluster

### DIFF
--- a/handlers/live_test.go
+++ b/handlers/live_test.go
@@ -30,47 +30,23 @@ func TestSetLiveClient(t *testing.T) {
 func TestDefaultMockData(t *testing.T) {
 	data := obs.DefaultMockData()
 
-	t.Run("has services", func(t *testing.T) {
-		assert.NotEmpty(t, data.Services)
+	t.Run("reports no live metrics", func(t *testing.T) {
+		assert.False(t, data.HasMetrics, "fallback must not claim live metrics")
 	})
 
-	t.Run("services have names from the cluster", func(t *testing.T) {
-		names := make(map[string]bool)
-		for _, svc := range data.Services {
-			names[svc.Name] = true
-		}
-		assert.True(t, names["source-controller"])
-		assert.True(t, names["platform-website"])
-		assert.True(t, names["cilium-operator"])
+	t.Run("fabricates no hosts", func(t *testing.T) {
+		// The fallback must not invent a cluster. The site's /privacy notice
+		// promises the live grid shows real infrastructure, so on failure the
+		// fallback surfaces "topology unavailable" rather than decoy nodes.
+		assert.Empty(t, data.Hosts, "fallback must not fabricate nodes")
 	})
 
-	t.Run("services have CPU and RAM", func(t *testing.T) {
-		for _, svc := range data.Services {
-			if svc.Status == "healthy" && svc.CPU > 0 || svc.RAM > 0 {
-				assert.GreaterOrEqual(t, svc.CPU, float64(0), "Service %s", svc.Name)
-				assert.GreaterOrEqual(t, svc.RAM, float64(0), "Service %s", svc.Name)
-			}
-		}
+	t.Run("fabricates no services", func(t *testing.T) {
+		assert.Empty(t, data.Services, "fallback must not fabricate services")
 	})
 
-	t.Run("services have categories", func(t *testing.T) {
-		for _, svc := range data.Services {
-			assert.NotEmpty(t, svc.Category, "Service %s", svc.Name)
-		}
-	})
-
-	t.Run("hosts are present", func(t *testing.T) {
-		assert.GreaterOrEqual(t, len(data.Hosts), 2)
-		names := make(map[string]bool)
-		for _, h := range data.Hosts {
-			names[h.Name] = true
-		}
-		assert.True(t, names["talos-oci-c-rapid-gator"])
-		assert.True(t, names["talos-edge-w-known-foal"])
-	})
-
-	t.Run("has no live metrics in mock mode", func(t *testing.T) {
-		assert.False(t, data.HasMetrics)
+	t.Run("carries a timestamp", func(t *testing.T) {
+		assert.NotZero(t, data.Timestamp)
 	})
 }
 

--- a/obs/mock.go
+++ b/obs/mock.go
@@ -15,34 +15,21 @@ func (m *MockClient) Fetch(_ context.Context) (LiveData, error) {
 	return m.Data, m.Err
 }
 
-// DefaultMockData returns a static snapshot showing the node strip layout.
+// DefaultMockData returns an empty snapshot used as the fallback when the live
+// topology source is unavailable (empty result or fetch error).
+//
+// It deliberately returns NO hosts and NO services. This site's central claim
+// (stated on /privacy) is that the live grid shows our real infrastructure.
+// Fabricating a plausible-looking cluster on failure would silently break that
+// promise, so the fallback surfaces "topology unavailable" via the section's
+// degraded rendering (HasMetrics=false) instead of inventing nodes.
+//
+// Dev/preview environments that want a populated sample should inject their
+// own Client via SetLiveClient, not rely on this fallback.
 func DefaultMockData() LiveData {
-	now := time.Now().Unix()
 	return LiveData{
 		SelfNamespace: "platform-website",
-		Hosts: []Host{
-			{Name: "talos-oci-c-rapid-gator", Label: "Control plane", Detail: "OCI Cloud \u00b7 ARM64", CPU: 0.58, CPUCores: 4, RAM: 4.3, RAMTotal: 23950, Uptime: "8d", SvcCount: 9},
-			{Name: "talos-edge-w-known-foal", Label: "Worker", Detail: "Edge \u00b7 AMD64", CPU: 4.77, CPUCores: 16, RAM: 13814, RAMTotal: 48038, Uptime: "8d", SvcCount: 21},
-			{Name: "talos-os-w-lasting-phoenix", Label: "Worker", Detail: "Cloud \u00b7 AMD64", CPU: 0.22, CPUCores: 16, RAM: 3051, RAMTotal: 32068, Uptime: "2m", SvcCount: 4},
-		},
-		Services: []Service{
-			{Name: "arc-controller-gha-rs-controller", Namespace: "arc-systems", Category: "dev", Host: "talos-oci-c-rapid-gator", Status: "healthy", CPU: 0.1, RAM: 64},
-			{Name: "forgejo-valkey-primary", Namespace: "forgejo", Category: "dev", Host: "talos-edge-w-known-foal", Status: "healthy", CPU: 0.0, RAM: 14},
-			{Name: "cert-manager", Namespace: "cert-manager", Category: "deployment", Host: "talos-edge-w-known-foal", Status: "healthy", CPU: 0.06, RAM: 73, Uptime: "1d"},
-			{Name: "external-dns", Namespace: "external-dns", Category: "deployment", Host: "talos-edge-w-known-foal", Status: "healthy", CPU: 0.10, RAM: 94, Uptime: "1d"},
-			{Name: "source-controller", Namespace: "flux-system", Category: "deployment", Host: "talos-oci-c-rapid-gator", Status: "healthy", CPU: 0.44, RAM: 118, Uptime: "8d"},
-			{Name: "kube-prometheus-stack-operator", Namespace: "monitoring", Category: "deployment", Host: "talos-edge-w-known-foal", Status: "healthy", CPU: 0.29, RAM: 111, Uptime: "12h"},
-			{Name: "platform-website", Namespace: "platform-website", Category: "runtime", Host: "talos-edge-w-known-foal", Status: "healthy", CPU: 0.11, RAM: 121, Uptime: "22h"},
-			{Name: "dapr-operator", Namespace: "dapr-system", Category: "runtime", Host: "talos-edge-w-known-foal", Status: "healthy", CPU: 0.13, RAM: 53, Uptime: "3d"},
-			{Name: "cilium-operator", Namespace: "kube-system", Category: "runtime", Host: "talos-edge-w-known-foal", Status: "healthy", Uptime: "8d"},
-			{Name: "prometheus", Namespace: "monitoring", Category: "observability", Host: "talos-edge-w-known-foal", Status: "healthy", Uptime: "6h"},
-			{Name: "juicefs-csi-controller", Namespace: "juicefs-csi", Category: "data", Host: "talos-edge-w-known-foal", Status: "healthy", Uptime: "1d"},
-			{Name: "juicefs-tikv-pd", Namespace: "tikv-system", Category: "data", Host: "talos-edge-w-known-foal", Status: "healthy", CPU: 3.82, RAM: 173, Uptime: "8d"},
-			{Name: "actions-runner", Namespace: "arc-systems", Category: "dev", Host: "talos-os-w-lasting-phoenix", Status: "healthy", CPU: 0.05, RAM: 42},
-			{Name: "flux-kustomization-controller", Namespace: "flux-system", Category: "deployment", Host: "talos-os-w-lasting-phoenix", Status: "healthy", CPU: 0.18, RAM: 88, Uptime: "1d"},
-			{Name: "coredns", Namespace: "kube-system", Category: "runtime", Host: "talos-os-w-lasting-phoenix", Status: "healthy", CPU: 0.02, RAM: 28},
-		},
-		HasMetrics: false,
-		Timestamp:  now,
+		HasMetrics:    false,
+		Timestamp:     time.Now().Unix(),
 	}
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -12,9 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rezuscloud/platform-website/handlers"
+	"github.com/rezuscloud/platform-website/obs"
 )
 
 func setupIntegrationApp() *fiber.App {
+	// Inject a populated sample so structure tests can assert rendering.
+	// The production fallback (obs.DefaultMockData) is deliberately empty.
+	handlers.SetLiveClient(&obs.MockClient{Data: sampleLiveData()})
 	return handlers.SetupApp()
 }
 

--- a/tests/sampledata_test.go
+++ b/tests/sampledata_test.go
@@ -1,0 +1,34 @@
+package tests
+
+import "github.com/rezuscloud/platform-website/obs"
+
+// sampleLiveData is a realistic, current-cluster snapshot used ONLY by the
+// integration/e2e tests to verify the live section's rendering structure. It is
+// not the production fallback (that is obs.DefaultMockData, which is
+// deliberately empty so the site never fabricates a cluster on failure).
+//
+// Node names match the real cluster at time of writing so test fixtures do not
+// drift into obvious fiction, but this is test data, not a source of truth.
+func sampleLiveData() obs.LiveData {
+	return obs.LiveData{
+		SelfNamespace: "platform-website",
+		HasMetrics:    false,
+		Hosts: []obs.Host{
+			{Name: "talos-oci-c-beloved-kite", Label: "Control plane", Detail: "OCI Cloud \u00b7 ARM64", CPU: 0.6, CPUCores: 4, RAM: 4300, RAMTotal: 23950, Uptime: "8d", SvcCount: 9},
+			{Name: "talos-edge-w-frank-antelope", Label: "Worker", Detail: "Edge \u00b7 AMD64", CPU: 4.8, CPUCores: 16, RAM: 13814, RAMTotal: 48038, Uptime: "8d", SvcCount: 21},
+			{Name: "talos-edge-w-next-bug", Label: "Worker", Detail: "Edge \u00b7 AMD64", CPU: 0.2, CPUCores: 64, RAM: 3051, RAMTotal: 257800, Uptime: "2m", SvcCount: 4},
+		},
+		Services: []obs.Service{
+			{Name: "source-controller", Namespace: "flux-system", Category: "deployment", Host: "talos-oci-c-beloved-kite", Status: "healthy", CPU: 0.44, RAM: 118, Uptime: "8d"},
+			{Name: "kube-prometheus-stack-operator", Namespace: "monitoring", Category: "deployment", Host: "talos-edge-w-frank-antelope", Status: "healthy", CPU: 0.29, RAM: 111, Uptime: "12h"},
+			{Name: "platform-website", Namespace: "platform-website", Category: "runtime", Host: "talos-edge-w-frank-antelope", Status: "healthy", CPU: 0.11, RAM: 121, Uptime: "22h"},
+			{Name: "dapr-operator", Namespace: "dapr-system", Category: "runtime", Host: "talos-edge-w-frank-antelope", Status: "healthy", CPU: 0.13, RAM: 53, Uptime: "3d"},
+			{Name: "cilium-operator", Namespace: "kube-system", Category: "runtime", Host: "talos-edge-w-frank-antelope", Status: "healthy", Uptime: "8d"},
+			{Name: "prometheus", Namespace: "monitoring", Category: "observability", Host: "talos-edge-w-frank-antelope", Status: "healthy", Uptime: "6h"},
+			{Name: "cert-manager", Namespace: "cert-manager", Category: "deployment", Host: "talos-edge-w-frank-antelope", Status: "healthy", CPU: 0.06, RAM: 73, Uptime: "1d"},
+			{Name: "juicefs-tikv-pd", Namespace: "tikv-system", Category: "data", Host: "talos-edge-w-frank-antelope", Status: "healthy", CPU: 3.82, RAM: 173, Uptime: "8d"},
+			{Name: "forgejo-runner", Namespace: "forgejo", Category: "dev", Host: "talos-edge-w-next-bug", Status: "healthy", CPU: 0.05, RAM: 42},
+			{Name: "actions-runner", Namespace: "arc-systems", Category: "dev", Host: "talos-edge-w-next-bug", Status: "healthy", CPU: 0.18, RAM: 88, Uptime: "1d"},
+		},
+	}
+}


### PR DESCRIPTION
Closes #99.

## What was wrong

`obs.DefaultMockData()` is the fallback used when the live topology source is unreachable (empty result or fetch error). It is wired into \`Home()\`, the \`live\` section factory, the SSE \`sendSnapshot()\`, and the default dev/preview \`liveClient\`.

It returned a static snapshot of a **pre-rebuild cluster** (\`talos-oci-c-rapid-gator\`, \`talos-edge-w-known-foal\`, \`talos-os-w-lasting-phoenix\`) that no longer exists. The site's central claim (stated explicitly on \`/privacy\`) is that the live grid shows our **real** infrastructure; on a topology fetch failure, visitors would have seen a fabricated-but-plausible decoy cluster, silently breaking that promise.

## Fix

Return an **empty snapshot** (\`HasMetrics=false\`, no hosts, no services) so the section renders its existing degraded state (\"topology unavailable\") instead of inventing nodes. Cannot lie by construction: there is no data to fabricate from.

Dev/preview environments that want a populated view should inject their own \`Client\` via \`SetLiveClient\`, not rely on the production fallback.

## Changes

- \`obs/mock.go\`: \`DefaultMockData()\` now returns empty \`LiveData\` (+ doc comment explaining the honesty contract).
- \`handlers/live_test.go\`: \`TestDefaultMockData\` rewritten to assert the honest contract (no fabricated hosts/services, \`HasMetrics=false\`, timestamp set).
- \`tests/sampledata_test.go\` (new) + \`tests/integration_test.go\`: structure tests that need populated rendering now inject a realistic current-cluster sample via \`SetLiveClient\`, instead of leaning on the (now-empty) production fallback.

## Verification

- \`gofmt\` / \`go vet\` clean; \`go test ./...\` green.
- \`DefaultMockData()\` confirmed empty (\`hosts=0 services=0 hasMetrics=false\`).
- Integration structure tests still pass against the injected sample.

## Note

Chose option (1) from the issue (honest fallback) over option (2) (refresh names): refreshing would rot again on the next rebuild and still lies when the fetch genuinely fails. The degraded rendering is the correct UX for \"topology unavailable\"; improving that degraded state (better messaging) is a follow-up if desired, separate from this correctness fix.