### PR TITLE
fix: .dockerignore excludes in-tree docs from Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,6 @@ node_modules/
 .github/
 Makefile
 .gitignore
-# Markdown files (but allow docs/external/ which is fetched at CI time)
-*.md
-!docs/external/**
+# Root-level markdown (README, etc.) — don't copy into the image.
+# In-tree docs under docs/ ARE needed at runtime (served by the docs store).
+/*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ ARG BUILD_TIME=unknown
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN if [ ! -f "docs/getting-started/what-is-rezuscloud.md" ]; then bash scripts/fetch-docs.sh; fi
 RUN templ generate
 COPY --from=tailwind /app/assets/styles.css ./assets/styles.css
 RUN test -n "${TARGETARCH}" && CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \

--- a/docs/embed.go
+++ b/docs/embed.go
@@ -20,7 +20,7 @@ func GetDocFS() fs.FS {
 	}
 
 	// Default: docs/ directory containing website-authored documentation.
-	// Organized by topic: getting-started/, concepts/, reference/, adr/
+	// Organized by topic: tutorials/, concepts/, reference/, adr/
 	defaultPath := filepath.Join("docs")
 	if info, err := os.Stat(defaultPath); err == nil && info.IsDir() {
 		return os.DirFS(defaultPath)

--- a/docs/registry.go
+++ b/docs/registry.go
@@ -2,7 +2,7 @@ package docs
 
 // RepoConfig defines a source repository for GitHub links.
 // The actual documentation content lives in the website's /docs folder,
-// organized by topic (getting-started, concepts, reference, adr).
+// organized by topic (tutorials, concepts, reference, adr).
 type RepoConfig struct {
 	// Name is the GitHub repository name under rezuscloud.
 	Name string

--- a/docs/store.go
+++ b/docs/store.go
@@ -11,7 +11,7 @@ import (
 
 // Doc represents a single rendered documentation page.
 type Doc struct {
-	// Path is the relative path from the docs root (e.g. "getting-started/install.md").
+	// Path is the relative path from the docs root (e.g. "what-is-rezuscloud.md").
 	Path string
 
 	// Title is extracted from the first H1 in the markdown.
@@ -20,7 +20,7 @@ type Doc struct {
 	// HTML is the rendered markdown content.
 	HTML string
 
-	// Category is the top-level directory (e.g. "getting-started", "concepts").
+	// Category is the top-level directory (e.g. "tutorials", "concepts").
 	Category string
 
 	// CategoryOrder controls sidebar display order. Lower = first.
@@ -55,8 +55,7 @@ var categoryDisplayNames = map[string]string{
 	"operations": "Operations",
 	"adr":        "Architecture Decisions",
 	// Legacy mappings (for backward compatibility with older doc trees).
-	"getting-started": "Getting Started",
-	"integrations":    "Integrations",
+	"integrations": "Integrations",
 }
 
 // CategoryDisplayName returns the display name for a category directory.
@@ -71,7 +70,7 @@ func CategoryDisplayName(cat string) string {
 type Store struct {
 	mu sync.RWMutex
 
-	// docs maps path → Doc (e.g. "getting-started/install.md" → Doc)
+	// docs maps path → Doc (e.g. "what-is-rezuscloud.md" → Doc)
 	docs map[string]Doc
 
 	// orderedPaths is a sorted list of all doc paths.
@@ -85,9 +84,7 @@ type Store struct {
 // basePath should contain category directories with markdown files:
 //
 //	basePath/
-//	  getting-started/
-//	    install.md
-//	    what-is-rezuscloud.md
+//	  what-is-rezuscloud.md
 //	  concepts/
 //	    architecture.md
 //	  reference/
@@ -166,7 +163,7 @@ func shouldIndex(relPath string) bool {
 // addDoc indexes a single markdown file.
 //
 // Path conventions:
-//   - in-tree files (e.g. "getting-started/what-is-rezuscloud.md") are served
+//   - in-tree files (e.g. "what-is-rezuscloud.md") are served
 //     at their natural path with no source attribution unless the file
 //     carries an explicit <!-- source: repo:path --> comment.
 //   - files under external/<repo>/... are fetched from the named repo by

--- a/docs/what-is-rezuscloud.md
+++ b/docs/what-is-rezuscloud.md
@@ -33,4 +33,4 @@ This page is the website's high-level introduction. For everything technical, us
 - **Implementation context** — the [RezusCloud wiki](https://github.com/rezuscloud/llm-wiki) for how the pieces fit together across repos (entities, concepts, guides).
 - **Live demo** — the RezusCloud management plane running at [demo.rezus.cloud](https://demo.rezus.cloud) (login: `admin` / `changeme`).
 
-<!-- source: platform-website:docs/getting-started/what-is-rezuscloud.md -->
+<!-- source: platform-website:docs/what-is-rezuscloud.md -->


### PR DESCRIPTION
Closes #105.

## Root cause

`.dockerignore` had `*.md` which matched ALL markdown files at every level, including in-tree docs under `docs/`. Only `docs/external/**` (CI-fetched rezuscloud docs) survived. All website-authored docs returned 404 in production.

`https://rezus.cloud/docs/getting-started/what-is-rezuscloud` → 404, even though the file exists in the repo.

## Changes

1. **`.dockerignore`**: `*.md` → `/*.md` (only exclude root-level markdown like README.md)
2. **Dockerfile**: removed dead `if [ ! -f ... ]; then fetch-docs.sh` conditional (CI fetches separately via the "Fetch external docs" step)
3. **Moved** `docs/getting-started/what-is-rezuscloud.md` → `docs/what-is-rezuscloud.md` (root-level Overview — `getting-started/` is a legacy category removed from the rezuscloud repo during the Diátaxis reorg)
4. **Updated** `docs/store.go` comments to reference current file paths
5. **Removed** legacy `"getting-started": "Getting Started"` category mapping

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all pass)
- After deploy: `/docs/what-is-rezuscloud` should return 200