### PR TITLE
fix: production image missing in-tree docs + redirect renamed paths

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -43,6 +43,8 @@ dockers_v2:
     extra_files:
       - assets
       - docs/external
+      - docs/what-is-rezuscloud.md
+      - docs/contributing
     labels:
       org.opencontainers.image.title: RezusCloud Platform Website
       org.opencontainers.image.description: RezusCloud Personal Cloud website

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -7,6 +7,8 @@ WORKDIR /app
 COPY ${TARGETPLATFORM}/platform-website /app/server
 COPY assets /app/assets
 COPY docs/external /app/docs/external
+COPY docs/what-is-rezuscloud.md /app/docs/
+COPY docs/contributing /app/docs/contributing
 
 EXPOSE 3000
 

--- a/docs/store.go
+++ b/docs/store.go
@@ -66,6 +66,24 @@ func CategoryDisplayName(cat string) string {
 	return strings.Title(cat)
 }
 
+// DocRedirects maps old doc paths (without .md) to new paths (without .md).
+// Used when docs are renamed or moved during reorganizations so old URLs
+// redirect (301) instead of 404.
+var DocRedirects = map[string]string{
+	// Diátaxis reorg (PR #169) — getting-started/ → tutorials/ + concepts/
+	"getting-started/index":              "tutorials/install-and-first-cluster",
+	"getting-started/multi-cluster":      "concepts/multi-cluster",
+	"getting-started/what-is-rezuscloud": "what-is-rezuscloud",
+	"getting-started/install":            "tutorials/install-and-first-cluster",
+	// integrations/ → how-to/
+	"integrations/home-assistant": "how-to/integrate-home-assistant",
+}
+
+// Redirect returns the new path for a renamed doc, or "" if no redirect exists.
+func Redirect(oldPath string) string {
+	return DocRedirects[oldPath]
+}
+
 // Store reads and caches documentation from the filesystem.
 type Store struct {
 	mu sync.RWMutex

--- a/handlers/docs.go
+++ b/handlers/docs.go
@@ -54,6 +54,14 @@ func DocsIndex(c *fiber.Ctx) error {
 // DocsPage renders a single documentation page.
 // Accepts paths like /docs/getting-started/install or /docs/concepts/architecture.
 func DocsPage(c *fiber.Ctx) error {
+	// Check for a redirect (renamed/moved docs) before anything else —
+	// redirects don't depend on the docs store being loaded.
+	if docPath := c.Params("*"); docPath != "" {
+		if newPath := docs.Redirect(docPath); newPath != "" {
+			return c.Redirect("/docs/"+newPath, http.StatusMovedPermanently)
+		}
+	}
+
 	if DocsStore == nil {
 		return c.Status(http.StatusNotFound).SendString("Documentation not available")
 	}

--- a/handlers/docs_redirect_test.go
+++ b/handlers/docs_redirect_test.go
@@ -1,0 +1,68 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDocsRedirect_RenamedPaths(t *testing.T) {
+	app := setupApp()
+
+	tests := []struct {
+		oldPath     string
+		wantStatus  int
+		wantLocPath string
+	}{
+		// Diátaxis reorg: getting-started/ → tutorials/ + concepts/
+		{"/docs/getting-started/index", 301, "/docs/tutorials/install-and-first-cluster"},
+		{"/docs/getting-started/multi-cluster", 301, "/docs/concepts/multi-cluster"},
+		{"/docs/getting-started/what-is-rezuscloud", 301, "/docs/what-is-rezuscloud"},
+		{"/docs/getting-started/install", 301, "/docs/tutorials/install-and-first-cluster"},
+		// integrations/ → how-to/
+		{"/docs/integrations/home-assistant", 301, "/docs/how-to/integrate-home-assistant"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.oldPath, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.oldPath, nil)
+			resp, err := app.Test(req, -1)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.wantStatus, resp.StatusCode,
+				"%s: expected %d, got %d", tt.oldPath, tt.wantStatus, resp.StatusCode)
+			assert.Equal(t, tt.wantLocPath, resp.Header.Get("Location"),
+				"%s: expected redirect to %s, got %s", tt.oldPath, tt.wantLocPath, resp.Header.Get("Location"))
+		})
+	}
+}
+
+func TestDocsRedirect_NonRenamedPathNoRedirect(t *testing.T) {
+	app := setupApp()
+
+	// A path that doesn't exist and isn't in the redirect map should 404, not redirect.
+	req := httptest.NewRequest("GET", "/docs/nonexistent/deep/path", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.NotEqual(t, 301, resp.StatusCode, "non-renamed paths must not redirect")
+	assert.NotEqual(t, 302, resp.StatusCode, "non-renamed paths must not redirect")
+}
+
+func TestDocsRedirect_ValidDocNotRedirected(t *testing.T) {
+	app := setupApp()
+
+	// A valid existing doc should render (200 or 404 if store is empty in tests),
+	// but must NOT redirect.
+	req := httptest.NewRequest("GET", "/docs/tutorials/install-and-first-cluster", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.NotEqual(t, 301, resp.StatusCode, "valid docs must not redirect")
+	assert.NotEqual(t, 302, resp.StatusCode, "valid docs must not redirect")
+}


### PR DESCRIPTION
Closes #107.

## Root cause (real this time)

PR #106 fixed `.dockerignore` for `Dockerfile` — but **production uses `Dockerfile.release`**, built by GoReleaser with a separate build context. The production image only ever copied `docs/external/`. In-tree docs were absent. `.dockerignore` was irrelevant.

Separately, renamed doc paths (`getting-started/index` → `tutorials/install-and-first-cluster`) returned 404 instead of redirecting.

## Changes

1. **`Dockerfile.release`**: `COPY docs/what-is-rezuscloud.md` + `COPY docs/contributing` alongside `docs/external`
2. **GoReleaser `extra_files`**: added `docs/what-is-rezuscloud.md` + `docs/contributing` to the build context
3. **`docs.Redirect` map**: old → new paths for Diátaxis reorg renames
4. **`DocsPage` handler**: redirect check runs **before** `DocsStore` nil guard (redirects don't depend on the store)
5. **Tests**: redirect map correctness, non-renamed paths don't redirect, valid docs don't redirect

## Acceptance criteria

After deploy:
- `/docs/what-is-rezuscloud` → 200
- `/docs/getting-started/index` → 301 → `/docs/tutorials/install-and-first-cluster`
- `/docs/getting-started/what-is-rezuscloud` → 301 → `/docs/what-is-rezuscloud`