### PR TITLE
feat: multi-version doc fetch with minor-version retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Format check (Go)
         run: test -z "$(gofmt -l .)"
 
+      - name: Run shell unit tests (fetch-docs version selection)
+        run: bash scripts/fetch-docs.test.sh
+
       - name: Vet
         run: go vet ./...
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ Thumbs.db
 # Air live reload
 tmp/
 
-# Fetched documentation (legacy, no longer used)
+# Fetched documentation (build artifacts — produced by scripts/fetch-docs.sh)
 docs/external/
+docs/versions/
 repo-map.json

--- a/docs/store.go
+++ b/docs/store.go
@@ -169,9 +169,17 @@ func (s *Store) loadFromFS(fsys fs.FS) error {
 // shouldIndex reports whether a markdown file should be exposed in the docs UI.
 // ADRs are kept in the repos as decision records but are not surfaced as
 // end-user documentation.
+//
+// The versions/ subtree contains multi-version docs managed by fetch-docs.sh
+// and read by the versioned Store (#110). Until the versioned Store is
+// implemented, the legacy Store must not index these — they would collide
+// with the backward-compat docs/external/ copies.
 func shouldIndex(relPath string) bool {
 	for _, seg := range strings.Split(relPath, "/") {
 		if seg == "adr" {
+			return false
+		}
+		if seg == "versions" {
 			return false
 		}
 	}

--- a/scripts/fetch-docs.sh
+++ b/scripts/fetch-docs.sh
@@ -1,53 +1,76 @@
 #!/usr/bin/env bash
-# fetch-docs.sh - Fetch documentation from configured repositories into docs/external/
+# fetch-docs.sh - Fetch rezuscloud documentation for multiple release versions.
 #
-# Uses `gh api` for authenticated downloads (works for private repos).
-# Falls back to unauthenticated git clone for public repos.
+# Produces docs/versions/ with:
+#   - One directory per retained release tag (deduplicated by minor version)
+#   - A docs/versions/next/ directory for unreleased main-branch docs
+#   - A docs/versions/manifest.json describing the available versions
+#
+# Retention policy (lib-versions.sh select_versions): for each minor version
+# line (major.minor), keep only the latest release. This is the Kubernetes/Helm
+# docs model. See lib-versions.sh for details.
+#
+# Backward compatibility: also copies the latest version's docs to
+# docs/external/rezuscloud/ so the current (pre-versioning) Store keeps working
+# until the versioned Store (#110) lands.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-TARGET_DIR="$SCRIPT_DIR/../docs/external"
+source "$SCRIPT_DIR/lib-versions.sh"
 
-# Ensure clean state
+ORG="rezuscloud"
+REPO="rezuscloud"
+DOCS_PATH="docs"
+NEXT_BRANCH="main"
+
+DOCS_ROOT="$SCRIPT_DIR/../docs"
+TARGET_DIR="$DOCS_ROOT/versions"
+EXTERNAL_DIR="$DOCS_ROOT/external"
+
+# Clean state — idempotent re-runs
 rm -rf "$TARGET_DIR"
+rm -rf "$EXTERNAL_DIR"
 mkdir -p "$TARGET_DIR"
 
-# List of repos to fetch docs from (name:docs_path:branch)
-# Source-of-truth: product docs live in rezuscloud/rezuscloud.
-# In-tree platform-website/docs/ pages are served directly and are not
-# re-fetched from this repo.
-REPOS=(
-    "rezuscloud:docs:main"
-)
+# ---------------------------------------------------------------------------
+# fetch_version_docs downloads a tarball of <org>/<repo> at <ref>, extracts
+# the docs/ directory, and copies it to <dest>. Returns 0 on success.
+# Uses gh api (authenticated) first, falls back to git clone (public repos).
+# ---------------------------------------------------------------------------
+fetch_version_docs() {
+    local ref="$1" dest="$2"
 
-# Download docs via GitHub tarball API (authenticated via gh CLI)
-# Usage: fetch_via_gh org repo branch docs_path dest
-fetch_via_gh() {
-    local org="$1" repo="$2" branch="$3" docs_path="$4" dest="$5"
+    if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+        _fetch_via_gh_tarball "$ref" "$dest" && return 0
+    fi
 
-    local tmpdir
+    _fetch_via_git_clone "$ref" "$dest"
+}
+
+_fetch_via_gh_tarball() {
+    local ref="$1" dest="$2"
+    local tmpdir tarball extracted
+
     tmpdir=$(mktemp -d)
-    local tarball="$tmpdir/repo.tar.gz"
+    tarball="$tmpdir/repo.tar.gz"
 
-    # Download tarball via gh api (authenticated)
-    if ! gh api "repos/${org}/${repo}/tarball/${branch}" > "$tarball" 2>/dev/null; then
+    if ! gh api "repos/${ORG}/${REPO}/tarball/${ref}" > "$tarball" 2>/dev/null; then
         rm -rf "$tmpdir"
         return 1
     fi
 
-    # Extract only the docs/ directory
     mkdir -p "$tmpdir/extract"
     tar -xzf "$tarball" -C "$tmpdir/extract" 2>/dev/null || {
         rm -rf "$tmpdir"
         return 1
     }
 
-    # Find the extracted directory (gh tarballs have a prefix like rezuscloud-repo-hash/)
-    local extracted
+    # gh tarballs have a prefix like rezuscloud-repo-<hash>/
     extracted=$(find "$tmpdir/extract" -maxdepth 1 -type d | tail -1)
 
-    if [ -d "${extracted}/${docs_path}" ]; then
-        cp -r "${extracted}/${docs_path}/." "$dest/"
+    if [ -d "${extracted}/${DOCS_PATH}" ]; then
+        mkdir -p "$dest"
+        cp -r "${extracted}/${DOCS_PATH}/." "$dest/"
         rm -rf "$tmpdir"
         return 0
     fi
@@ -56,42 +79,114 @@ fetch_via_gh() {
     return 1
 }
 
-for entry in "${REPOS[@]}"; do
-    IFS=':' read -r repo docs_path branch <<< "$entry"
-    echo "Fetching docs from rezuscloud/$repo ($docs_path/)..."
+_fetch_via_git_clone() {
+    local ref="$1" dest="$2"
+    local tmpdir
 
-    dest="$TARGET_DIR/$repo"
-    mkdir -p "$dest"
-
-    # Try authenticated download via gh CLI first
-    if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
-        if fetch_via_gh "rezuscloud" "$repo" "$branch" "$docs_path" "$dest"; then
-            count=$(find "$dest" -name '*.md' | wc -l)
-            echo "  ✓ Fetched $count markdown files via gh"
-            continue
-        fi
-        echo "  gh download incomplete, trying git clone..."
-    fi
-
-    # Fallback: git clone (works for public repos without auth)
     tmpdir=$(mktemp -d)
-    if git clone --depth 1 --branch "$branch" "https://github.com/rezuscloud/$repo.git" "$tmpdir/repo" 2>/dev/null; then
-        if [ -d "$tmpdir/repo/$docs_path" ]; then
-            cp -r "$tmpdir/repo/$docs_path/." "$dest/"
-            count=$(find "$dest" -name '*.md' | wc -l)
-            echo "  ✓ Fetched $count markdown files"
-        else
-            echo "  ⚠ No $docs_path/ directory found"
+    if git clone --depth 1 --branch "$ref" "https://github.com/${ORG}/${REPO}.git" "$tmpdir/repo" 2>/dev/null; then
+        if [ -d "$tmpdir/repo/$DOCS_PATH" ]; then
+            mkdir -p "$dest"
+            cp -r "$tmpdir/repo/$DOCS_PATH/." "$dest/"
+            rm -rf "$tmpdir"
+            return 0
         fi
-    else
-        echo "  ⚠ Could not fetch $repo docs, skipping"
     fi
-    rm -rf "$tmpdir"
-done
 
-# Ensure at least one file exists
-if [ -z "$(find "$TARGET_DIR" -type f)" ]; then
-    echo "# Documentation" > "$TARGET_DIR/README.md"
+    rm -rf "$tmpdir"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# 1. Query all release tags + creation dates.
+# ---------------------------------------------------------------------------
+if ! command -v jq &>/dev/null; then
+    echo "ERROR: jq is required for multi-version doc fetching" >&2
+    exit 1
 fi
 
-echo "Done. Docs available in $TARGET_DIR/"
+echo "Querying releases from ${ORG}/${REPO}..."
+ALL_RELEASES=$(gh release list --repo "${ORG}/${REPO}" --json tagName,createdAt --limit 500 2>/dev/null | \
+    jq -r '.[] | "\(.createdAt)\t\(.tagName)"' || echo "")
+
+if [ -z "$ALL_RELEASES" ]; then
+    echo "  No releases found (or gh not authenticated). Fetching next only."
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Select versions: dedup by minor version, keep latest of each.
+# ---------------------------------------------------------------------------
+ALL_TAGS=$(echo "$ALL_RELEASES" | cut -f2)
+SELECTED=""
+if [ -n "$ALL_TAGS" ]; then
+    SELECTED=$(echo "$ALL_TAGS" | select_versions)
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Fetch each selected version's docs.
+# ---------------------------------------------------------------------------
+MANIFEST_ARGS=()
+LATEST_TAG=""
+LATEST_DATE=""
+LATEST_MINOR=""
+
+while IFS= read -r tag; do
+    [ -z "$tag" ] && continue
+
+    # Look up the release date for this tag
+    date=$(echo "$ALL_RELEASES" | grep -P "\t${tag}$" | cut -f1)
+    minor=$(extract_minor_key "$tag") || minor=""
+
+    echo "Fetching docs for ${tag} (minor ${minor})..."
+    if fetch_version_docs "$tag" "$TARGET_DIR/$tag"; then
+        count=$(find "$TARGET_DIR/$tag" -name '*.md' | wc -l)
+        echo "  ✓ ${tag}: ${count} markdown files"
+        MANIFEST_ARGS+=("$tag" "$minor" "$date")
+        # First selected tag is the latest (select_versions sorts newest-first)
+        if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="$tag"
+            LATEST_DATE="$date"
+            LATEST_MINOR="$minor"
+        fi
+    else
+        echo "  ⚠ Could not fetch ${tag}, skipping"
+    fi
+done <<< "$SELECTED"
+
+# ---------------------------------------------------------------------------
+# 4. Fetch next (unreleased main branch).
+# ---------------------------------------------------------------------------
+echo "Fetching docs for next (${NEXT_BRANCH})..."
+if fetch_version_docs "$NEXT_BRANCH" "$TARGET_DIR/next"; then
+    count=$(find "$TARGET_DIR/next" -name '*.md' | wc -l)
+    echo "  ✓ next: ${count} markdown files"
+    MANIFEST_ARGS+=("--" "next")
+else
+    echo "  ⚠ Could not fetch next, versioned docs will not include unreleased"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Write manifest.
+# ---------------------------------------------------------------------------
+if [ ${#MANIFEST_ARGS[@]} -gt 0 ]; then
+    write_manifest "$TARGET_DIR/manifest.json" "${MANIFEST_ARGS[@]}"
+    echo "  ✓ Manifest written: $(cat "$TARGET_DIR/manifest.json" | jq -r '.latest') latest"
+else
+    # Fallback: no versions at all — write an empty manifest
+    echo '{"latest":"","next":"","versions":[]}' > "$TARGET_DIR/manifest.json"
+    echo "  ⚠ No versions fetched, wrote empty manifest"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Backward compatibility: copy latest version to docs/external/rezuscloud/.
+#    The current (pre-versioning) Store strips external/<repo>/ and serves
+#    these at their natural path. This keeps the live site working until the
+#    versioned Store (#110) lands.
+# ---------------------------------------------------------------------------
+if [ -n "$LATEST_TAG" ]; then
+    mkdir -p "$EXTERNAL_DIR/rezuscloud"
+    cp -r "$TARGET_DIR/$LATEST_TAG/." "$EXTERNAL_DIR/rezuscloud/"
+    echo "  ✓ Backward-compat: latest (${LATEST_TAG}) copied to docs/external/rezuscloud/"
+fi
+
+echo "Done. Versioned docs in ${TARGET_DIR}/"

--- a/scripts/fetch-docs.test.sh
+++ b/scripts/fetch-docs.test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# fetch-docs.test.sh — Unit tests for lib-versions.sh (pure version selection).
+#
+# Run: bash scripts/fetch-docs.test.sh
+# Exit code 0 = all pass, 1 = at least one failure.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib-versions.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        printf "  ✓ %s\n" "$desc"
+    else
+        FAIL=$((FAIL + 1))
+        printf "  ✗ %s\n" "$desc"
+        printf "    expected: %s\n" "$expected"
+        printf "    actual:   %s\n" "$actual"
+    fi
+}
+
+echo "=== extract_minor_key ==="
+
+assert_eq "v0.0.1-106 → 0.0" \
+    "0.0" "$(extract_minor_key "v0.0.1-106")"
+
+assert_eq "v0.1.0 → 0.1" \
+    "0.1" "$(extract_minor_key "v0.1.0")"
+
+assert_eq "v1.2.3 → 1.2" \
+    "1.2" "$(extract_minor_key "v1.2.3")"
+
+assert_eq "v0.0.1-9 → 0.0" \
+    "0.0" "$(extract_minor_key "v0.0.1-9")"
+
+assert_eq "v10.20.30 → 10.20" \
+    "10.20" "$(extract_minor_key "v10.20.30")"
+
+# Unparseable tags return non-zero
+if extract_minor_key "not-a-version" 2>/dev/null; then
+    assert_eq "not-a-version should fail" "fail" "succeeded"
+else
+    PASS=$((PASS + 1))
+    printf "  ✓ not-a-version correctly rejected\n"
+fi
+
+echo ""
+echo "=== select_versions (single minor line) ==="
+
+# All tags are minor 0.0 — should deduplicate to just the latest
+RESULT=$(printf 'v0.0.1-99\nv0.0.1-100\nv0.0.1-106\nv0.0.1-105\n' | select_versions)
+assert_eq "single minor: only latest kept" \
+    "v0.0.1-106" "$RESULT"
+
+echo ""
+echo "=== select_versions (multiple minor lines) ==="
+
+# Two minor lines: 0.0 and 0.1. Each line deduplicates to its latest.
+# v0.1.0 and v0.1.1 are both minor 0.1 → only v0.1.1 (latest) kept.
+RESULT=$(printf 'v0.0.1-106\nv0.1.0\nv0.0.1-99\nv0.1.1\n' | select_versions)
+EXPECTED="v0.1.1
+v0.0.1-106"
+assert_eq "multiple minors: one per line, newest-first" \
+    "$EXPECTED" "$RESULT"
+
+echo ""
+echo "=== select_versions (numeric prerelease sort) ==="
+
+# Ensure 0.0.1-100 > 0.0.1-9 (not string sort)
+RESULT=$(printf 'v0.0.1-9\nv0.0.1-100\nv0.0.1-50\n' | select_versions)
+assert_eq "numeric prerelease: 100 > 9" \
+    "v0.0.1-100" "$RESULT"
+
+echo ""
+echo "=== select_versions (three minor lines) ==="
+
+RESULT=$(printf 'v0.0.5\nv1.0.0\nv0.1.3\nv0.0.1-106\nv1.1.0\nv0.1.0\n' | select_versions)
+EXPECTED="v1.1.0
+v1.0.0
+v0.1.3
+v0.0.5"
+assert_eq "three minor lines, correct dedup + sort" \
+    "$EXPECTED" "$RESULT"
+
+echo ""
+echo "=== write_manifest ==="
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+write_manifest "$TMPDIR/manifest.json" \
+    "v0.0.1-106" "0.0" "2026-07-09T11:18:15Z" \
+    -- next
+
+MANIFEST=$(cat "$TMPDIR/manifest.json")
+
+# Verify latest field
+LATEST=$(grep '"latest"' "$TMPDIR/manifest.json" | cut -d'"' -f4)
+assert_eq "manifest latest field" "v0.0.1-106" "$LATEST"
+
+# Verify next field (the top-level "next" key, not the version entry)
+NEXT=$(grep '  "next":' "$TMPDIR/manifest.json" | cut -d'"' -f4)
+assert_eq "manifest next field" "next" "$NEXT"
+
+# Verify version entry exists
+if grep -q '"version": "v0.0.1-106"' "$TMPDIR/manifest.json"; then
+    PASS=$((PASS + 1))
+    printf "  ✓ manifest contains version entry\n"
+else
+    FAIL=$((FAIL + 1))
+    printf "  ✗ manifest missing version entry\n"
+fi
+
+# Verify next entry exists
+if grep -q '"isNext": true' "$TMPDIR/manifest.json"; then
+    PASS=$((PASS + 1))
+    printf "  ✓ manifest contains next entry\n"
+else
+    FAIL=$((FAIL + 1))
+    printf "  ✗ manifest missing next entry\n"
+fi
+
+# Verify valid JSON (if jq available)
+if command -v jq &>/dev/null; then
+    if jq empty "$TMPDIR/manifest.json" 2>/dev/null; then
+        PASS=$((PASS + 1))
+        printf "  ✓ manifest is valid JSON\n"
+    else
+        FAIL=$((FAIL + 1))
+        printf "  ✗ manifest is invalid JSON\n"
+        cat "$TMPDIR/manifest.json"
+    fi
+fi
+
+echo ""
+echo "=== write_manifest (multiple versions) ==="
+
+write_manifest "$TMPDIR/manifest2.json" \
+    "v1.1.0" "1.1" "2026-08-01T10:00:00Z" \
+    "v1.0.0" "1.0" "2026-07-15T10:00:00Z" \
+    "v0.1.3" "0.1" "2026-07-10T10:00:00Z" \
+    -- next
+
+LATEST2=$(grep '"latest"' "$TMPDIR/manifest2.json" | cut -d'"' -f4)
+assert_eq "multi-version latest" "v1.1.0" "$LATEST2"
+
+VERSION_COUNT=$(grep -c '"version":' "$TMPDIR/manifest2.json")
+assert_eq "multi-version entry count (3 releases + 1 next = 4)" "4" "$VERSION_COUNT"
+
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/scripts/lib-versions.sh
+++ b/scripts/lib-versions.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# lib-versions.sh — Pure version-selection logic for multi-version doc fetching.
+#
+# Sourced by fetch-docs.sh (network orchestration) and fetch-docs.test.sh (unit
+# tests). Contains NO network calls — only semver parsing and deduplication.
+#
+# Retention policy: deduplicate releases by minor version (major.minor), keep
+# the latest release of each line. This is the Kubernetes/Helm docs model.
+# For the current rezuscloud 0.0.1-NN scheme, minor "0.0" deduplicates to the
+# highest -NN. When 0.1.0 ships, both "0.0" (latest) and "0.1" (latest) are kept.
+
+# select_versions reads release tags (one per line) on stdin and outputs the
+# retained tags (one per line), sorted newest-first.
+#
+# Each retained tag is the latest release of its minor version line.
+select_versions() {
+    declare -A seen_minor
+
+    # Sort all tags newest-first (version sort handles 0.0.1-106 > 0.0.1-9
+    # correctly, unlike naive string comparison).
+    local sorted
+    sorted=$(sort -rV)
+
+    while IFS= read -r tag; do
+        [ -z "$tag" ] && continue
+        local minor_key
+        minor_key=$(extract_minor_key "$tag") || continue
+
+        if [ -z "${seen_minor[$minor_key]:-}" ]; then
+            seen_minor[$minor_key]=1
+            echo "$tag"
+        fi
+    done <<< "$sorted"
+}
+
+# extract_minor_key parses a semver-ish tag and outputs "major.minor".
+# Returns non-zero if the tag cannot be parsed.
+#
+# Examples:
+#   v0.0.1-106  → 0.0
+#   v0.1.0      → 0.1
+#   v1.2.3      → 1.2
+extract_minor_key() {
+    local tag="$1"
+    local version="${tag#v}"          # strip leading v
+    local base="${version%%-*}"       # strip prerelease (-NN or -rc1)
+    # base is now "major.minor.patch"
+    if [[ ! "$base" =~ ^[0-9]+\.[0-9]+\. ]]; then
+        return 1
+    fi
+    # Extract major.minor (first two dot-separated fields)
+    local IFS='.'
+    read -r major minor _ <<< "$base"
+    echo "${major}.${minor}"
+}
+
+# manifest_entry emits a single JSON object for a version entry.
+# Usage: manifest_entry <version> <minor> <date>
+manifest_entry() {
+    local version="$1" minor="$2" date="$3"
+    printf '    {"version": "%s", "minor": "%s", "date": "%s"}' \
+        "$version" "$minor" "$date"
+}
+
+# manifest_entry_next emits the JSON object for the unreleased "next" entry.
+manifest_entry_next() {
+    printf '    {"version": "next", "label": "Unreleased (main)", "isNext": true}'
+}
+
+# write_manifest produces docs/versions/manifest.json from the selected versions.
+# Usage: write_manifest <output_path> <latest_tag> <minor_of_latest> <date_of_latest>
+#                        [tag2 minor2 date2] ... [-- next]
+#
+# The "-- next" sentinel appends the unreleased-next entry at the end.
+write_manifest() {
+    local output="$1"
+    shift
+
+    local entries=()
+    local has_next=false
+    local next_marker_seen=false
+
+    while [ $# -gt 0 ]; do
+        if [ "$1" = "--" ]; then
+            next_marker_seen=true
+            shift
+            if [ "$1" = "next" ]; then
+                has_next=true
+            fi
+            shift
+            continue
+        fi
+        # version minor date
+        entries+=("$(manifest_entry "$1" "$2" "$3")")
+        shift 3
+    done
+
+    {
+        echo "{"
+
+        # Determine latest from first entry (entries are sorted newest-first)
+        local latest="" latest_minor="" latest_date=""
+        if [ ${#entries[@]} -gt 0 ]; then
+            local first="${entries[0]}"
+            latest=$(echo "$first" | grep -o '"version": "[^"]*"' | head -1 | cut -d'"' -f4)
+        fi
+
+        printf '  "latest": "%s",\n' "$latest"
+        printf '  "next": "next",\n'
+        printf '  "versions": [\n'
+
+        local first=true
+        for entry in "${entries[@]}"; do
+            if [ "$first" = true ]; then
+                first=false
+            else
+                printf ',\n'
+            fi
+            printf '%s' "$entry"
+        done
+
+        if [ "$has_next" = true ]; then
+            if [ "$first" = false ]; then
+                printf ',\n'
+            fi
+            printf '%s' "$(manifest_entry_next)"
+        fi
+
+        printf '\n  ]\n'
+        echo "}"
+    } > "$output"
+}


### PR DESCRIPTION
Closes #109.

Build-time foundation for versioned documentation. Rewrites `fetch-docs.sh` to fetch rezuscloud docs for multiple release versions.

## What it does

1. **Queries all rezuscloud releases** via `gh release list`
2. **Deduplicates by minor version** (`major.minor`) — keeps the latest release of each line (Kubernetes/Helm docs model)
3. **Fetches each version's docs** into `docs/versions/<tag>/`
4. **Fetches unreleased main** into `docs/versions/next/`
5. **Writes `docs/versions/manifest.json`** with `latest`, `next`, and `versions[]`
6. **Backward-compat**: copies latest to `docs/external/rezuscloud/` so the current Store keeps working until #110

## Testable design

Version-selection logic extracted to `scripts/lib-versions.sh` (pure functions, no network). `fetch-docs.test.sh` provides 17 unit tests covering:
- Minor version extraction (`v0.0.1-106` → `0.0`, `v0.1.0` → `0.1`)
- Dedup by minor (single line, multiple lines, three lines)
- Numeric prerelease sort (`100 > 9`, not string sort)
- Manifest generation (single version, multiple versions, next entry, valid JSON)

CI runs the shell tests before the Go build.

## End-to-end verification (local)

```
docs/versions/
  manifest.json          → {"latest":"v0.0.1-106","next":"next","versions":[...]}
  v0.0.1-106/            → 62 markdown files
  next/                  → 62 markdown files
docs/external/rezuscloud/ → 62 markdown files (backward-compat copy of latest)
```

## Files

| File | Change |
|------|--------|
| `scripts/lib-versions.sh` | NEW — pure version-selection logic |
| `scripts/fetch-docs.test.sh` | NEW — 17 unit tests |
| `scripts/fetch-docs.sh` | Rewritten — multi-version orchestration |
| `.github/workflows/ci.yml` | +1 step: shell unit tests |
| `docs/store.go` | `shouldIndex` excludes `versions/` until #110 |
| `.gitignore` | + `docs/versions/` |

## Next

- #110: VersionedStore + version-aware routing (reads this manifest)
- #111: Version switcher UI
- #112: Docker + GoReleaser wiring (COPY docs/versions)