### PR TITLE
feat: VersionedStore + version-aware routing

### DIFF
--- a/docs/store.go
+++ b/docs/store.go
@@ -1,6 +1,7 @@
 package docs
 
 import (
+	"encoding/json"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -31,6 +32,37 @@ type Doc struct {
 
 	// GitHubEditURL links to edit the file on GitHub.
 	GitHubEditURL string
+}
+
+// Manifest describes the available documentation versions.
+// Written by scripts/fetch-docs.sh into docs/versions/manifest.json.
+type Manifest struct {
+	// Latest is the most recent release tag (e.g. "v0.0.1-106").
+	Latest string `json:"latest"`
+
+	// Next is the alias for unreleased main-branch docs ("next").
+	Next string `json:"next"`
+
+	// Versions lists all available versions, sorted newest-first.
+	Versions []VersionEntry `json:"versions"`
+}
+
+// VersionEntry describes a single documentation version.
+type VersionEntry struct {
+	// Version is the tag name (e.g. "v0.0.1-106") or "next".
+	Version string `json:"version"`
+
+	// Minor is the major.minor group (e.g. "0.0").
+	Minor string `json:"minor,omitempty"`
+
+	// Date is the release date (ISO 8601).
+	Date string `json:"date,omitempty"`
+
+	// Label is a human-readable label (e.g. "Unreleased (main)").
+	Label string `json:"label,omitempty"`
+
+	// IsNext marks the unreleased main-branch entry.
+	IsNext bool `json:"isNext,omitempty"`
 }
 
 // categoryOrder defines the sidebar display order for categories.
@@ -85,34 +117,40 @@ func Redirect(oldPath string) string {
 }
 
 // Store reads and caches documentation from the filesystem.
+//
+// Two loading modes:
+//
+//   - Versioned mode: a docs/versions/manifest.json is present. Version-specific
+//     docs are loaded from docs/versions/<tag>/, keyed per version. In-tree docs
+//     (root *.md, contributing/) are shared across all versions.
+//
+//   - Legacy mode: no manifest. All docs (external/ + in-tree) are loaded into a
+//     single flat map. This preserves backward compatibility with images built
+//     before versioned docs.
 type Store struct {
 	mu sync.RWMutex
 
-	// docs maps path → Doc (e.g. "what-is-rezuscloud.md" → Doc)
-	docs map[string]Doc
+	// manifest describes available versions. nil in legacy mode.
+	manifest *Manifest
 
-	// orderedPaths is a sorted list of all doc paths.
-	orderedPaths []string
+	// versionDocs maps version tag → (stripped-path → Doc) for version-specific docs.
+	// Only populated in versioned mode.
+	versionDocs map[string]map[string]Doc
 
-	// basePath is the root directory containing doc files.
+	// sharedDocs holds in-tree docs (stripped-path → Doc) that are the same across
+	// all versions. In legacy mode, this holds ALL docs (external + in-tree).
+	sharedDocs    map[string]Doc
+	orderedShared []string
+
 	basePath string
 }
 
 // NewStore creates a store that reads docs from basePath.
-// basePath should contain category directories with markdown files:
-//
-//	basePath/
-//	  what-is-rezuscloud.md
-//	  concepts/
-//	    architecture.md
-//	  reference/
-//	    cli.md
-//	  adr/
-//	    0001-foo.md
 func NewStore(basePath string) (*Store, error) {
 	s := &Store{
-		docs:     make(map[string]Doc),
-		basePath: basePath,
+		sharedDocs:  make(map[string]Doc),
+		versionDocs: make(map[string]map[string]Doc),
+		basePath:    basePath,
 	}
 	if err := s.loadFromDisk(); err != nil {
 		return nil, err
@@ -123,7 +161,8 @@ func NewStore(basePath string) (*Store, error) {
 // NewEmbeddedStore creates a store from an embedded filesystem.
 func NewEmbeddedStore(fsys fs.FS) (*Store, error) {
 	s := &Store{
-		docs: make(map[string]Doc),
+		sharedDocs:  make(map[string]Doc),
+		versionDocs: make(map[string]map[string]Doc),
 	}
 	if err := s.loadFromFS(fsys); err != nil {
 		return nil, err
@@ -132,48 +171,133 @@ func NewEmbeddedStore(fsys fs.FS) (*Store, error) {
 }
 
 func (s *Store) loadFromDisk() error {
-	return filepath.WalkDir(s.basePath, func(path string, d fs.DirEntry, err error) error {
-		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
-			return nil
-		}
-		relPath := strings.TrimPrefix(path, s.basePath+"/")
-		if !shouldIndex(relPath) {
-			return nil
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil
-		}
-		s.addDoc(relPath, data)
-		return nil
-	})
+	return s.loadFromFS(os.DirFS(s.basePath))
 }
 
 func (s *Store) loadFromFS(fsys fs.FS) error {
-	return fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+	// Try versioned mode: read manifest
+	if manifest, err := s.loadManifest(fsys); err == nil && manifest != nil {
+		s.manifest = manifest
+		s.loadVersionedDocs(fsys)
+		s.loadSharedDocs(fsys)
+		return nil
+	}
+
+	// Legacy mode: no manifest — load all docs into sharedDocs
+	s.loadLegacyDocs(fsys)
+	return nil
+}
+
+// loadManifest reads versions/manifest.json from the filesystem.
+func (s *Store) loadManifest(fsys fs.FS) (*Manifest, error) {
+	data, err := fs.ReadFile(fsys, "versions/manifest.json")
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	if len(m.Versions) == 0 {
+		return nil, fs.ErrNotExist
+	}
+	return &m, nil
+}
+
+// loadVersionedDocs walks docs/versions/<tag>/ for each version in the manifest.
+func (s *Store) loadVersionedDocs(fsys fs.FS) {
+	for _, v := range s.manifest.Versions {
+		versionDir := "versions/" + v.Version
+		docs := make(map[string]Doc)
+
+		// GitHub ref: use the tag for releases, "main" for next
+		ghRef := v.Version
+		if v.IsNext {
+			ghRef = "main"
+		}
+
+		fs.WalkDir(fsys, versionDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+				return nil
+			}
+			// Strip the versions/<tag>/ prefix BEFORE shouldIndex,
+			// otherwise shouldIndex rejects the path (versions segment).
+			relPath := strings.TrimPrefix(path, versionDir+"/")
+			if !shouldIndex(relPath) {
+				return nil
+			}
+			data, rerr := fs.ReadFile(fsys, path)
+			if rerr != nil {
+				return nil
+			}
+			doc := buildDoc(relPath, data, "rezuscloud", relPath, ghRef)
+			docs[relPath] = doc
+			return nil
+		})
+
+		s.versionDocs[v.Version] = docs
+	}
+}
+
+// loadSharedDocs walks in-tree docs (root *.md, contributing/) that are shared
+// across all versions. Excludes versions/, external/, adr/.
+func (s *Store) loadSharedDocs(fsys fs.FS) {
+	fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		// Skip versioned and external subtrees (handled separately)
+		if isExcludedPath(path) {
+			return nil
+		}
+		if !shouldIndex(path) {
+			return nil
+		}
+		data, rerr := fs.ReadFile(fsys, path)
+		if rerr != nil {
+			return nil
+		}
+		s.addSharedDoc(path, data)
+		return nil
+	})
+	s.rebuildSharedIndex()
+}
+
+// loadLegacyDocs loads all docs (external/ + in-tree) into sharedDocs.
+// Used when no manifest is present (backward compatibility).
+func (s *Store) loadLegacyDocs(fsys fs.FS) {
+	fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
 			return nil
 		}
 		if !shouldIndex(path) {
 			return nil
 		}
-		data, err := fs.ReadFile(fsys, path)
-		if err != nil {
+		data, rerr := fs.ReadFile(fsys, path)
+		if rerr != nil {
 			return nil
 		}
-		s.addDoc(path, data)
+		s.addSharedDoc(path, data)
 		return nil
 	})
+	s.rebuildSharedIndex()
+}
+
+// isExcludedPath reports whether a path is in a subtree that should not be
+// loaded as shared/in-tree docs (versions/ and external/ are handled by
+// versioned loading or legacy external stripping).
+func isExcludedPath(path string) bool {
+	for _, seg := range strings.Split(path, "/") {
+		if seg == "versions" || seg == "external" {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldIndex reports whether a markdown file should be exposed in the docs UI.
 // ADRs are kept in the repos as decision records but are not surfaced as
-// end-user documentation.
-//
-// The versions/ subtree contains multi-version docs managed by fetch-docs.sh
-// and read by the versioned Store (#110). Until the versioned Store is
-// implemented, the legacy Store must not index these — they would collide
-// with the backward-compat docs/external/ copies.
+// end-user documentation. The versions/ subtree is handled by versioned loading.
 func shouldIndex(relPath string) bool {
 	for _, seg := range strings.Split(relPath, "/") {
 		if seg == "adr" {
@@ -186,18 +310,30 @@ func shouldIndex(relPath string) bool {
 	return true
 }
 
-// addDoc indexes a single markdown file.
-//
-// Path conventions:
-//   - in-tree files (e.g. "what-is-rezuscloud.md") are served
-//     at their natural path with no source attribution unless the file
-//     carries an explicit <!-- source: repo:path --> comment.
-//   - files under external/<repo>/... are fetched from the named repo by
-//     scripts/fetch-docs.sh. The external/<repo>/ prefix is stripped from
-//     the served URL, and the repo is recorded as the source for GitHub
-//     view/edit links. The website is about rezuscloud; calling product
-//     docs "external" in the URL would be misleading.
-func (s *Store) addDoc(relPath string, data []byte) {
+// addSharedDoc indexes a markdown file into sharedDocs.
+// Handles external/<repo>/ prefix stripping for legacy mode.
+func (s *Store) addSharedDoc(relPath string, data []byte) {
+	// External/<repo>/ prefix stripping (legacy mode)
+	repoName, sourcePath := "", relPath
+	if parts := strings.SplitN(relPath, "/", 3); len(parts) == 3 && parts[0] == "external" {
+		repoName = parts[1]
+		sourcePath = parts[2]
+		relPath = parts[2]
+	}
+
+	// Explicit source comment overrides
+	if r, p := parseSource(data); r != "" {
+		repoName = r
+		sourcePath = p
+	}
+
+	doc := buildDoc(relPath, data, repoName, sourcePath, "")
+	s.sharedDocs[relPath] = doc
+}
+
+// buildDoc constructs a Doc from markdown data, extracting title, rendering
+// HTML, and computing GitHub URLs.
+func buildDoc(relPath string, data []byte, repoName, sourcePath, ghRef string) Doc {
 	title := ExtractTitle(data)
 	if title == "" {
 		base := strings.TrimSuffix(filepath.Base(relPath), ".md")
@@ -207,18 +343,7 @@ func (s *Store) addDoc(relPath string, data []byte) {
 
 	htmlContent, err := Render(data)
 	if err != nil {
-		return
-	}
-
-	// Default: source comes from an explicit comment in the file.
-	repoName, sourcePath := parseSource(data)
-
-	// Override: if the file lives under external/<repo>/..., the filesystem
-	// path is authoritative. Strip the prefix from the served URL.
-	if parts := strings.SplitN(relPath, "/", 3); len(parts) == 3 && parts[0] == "external" {
-		repoName = parts[1]
-		sourcePath = parts[2]
-		relPath = parts[2]
+		htmlContent = "<p>Failed to render document.</p>"
 	}
 
 	githubURL := ""
@@ -226,8 +351,15 @@ func (s *Store) addDoc(relPath string, data []byte) {
 	if repoName != "" {
 		repo := findRepo(repoName)
 		if repo != nil {
-			githubURL = repo.GitHubBaseURL() + "/" + sourcePath
-			githubEditURL = repo.GitHubEditURL() + "/" + sourcePath
+			ref := ghRef
+			if ref == "" {
+				ref = repo.VersionTag
+				if ref == "" {
+					ref = "main"
+				}
+			}
+			githubURL = "https://github.com/rezuscloud/" + repo.Name + "/blob/" + ref + "/" + repo.DocsPath + "/" + sourcePath
+			githubEditURL = "https://github.com/rezuscloud/" + repo.Name + "/edit/" + ref + "/" + repo.DocsPath + "/" + sourcePath
 		}
 	}
 
@@ -241,7 +373,7 @@ func (s *Store) addDoc(relPath string, data []byte) {
 		catOrder = order
 	}
 
-	s.docs[relPath] = Doc{
+	return Doc{
 		Path:          relPath,
 		Title:         title,
 		HTML:          htmlContent,
@@ -250,8 +382,6 @@ func (s *Store) addDoc(relPath string, data []byte) {
 		GitHubURL:     githubURL,
 		GitHubEditURL: githubEditURL,
 	}
-
-	s.rebuildIndex()
 }
 
 // parseSource extracts repo and path from a source comment in the markdown.
@@ -284,50 +414,161 @@ func findRepo(name string) *RepoConfig {
 	return nil
 }
 
-func (s *Store) rebuildIndex() {
-	paths := make([]string, 0, len(s.docs))
-	for p := range s.docs {
+func (s *Store) rebuildSharedIndex() {
+	paths := make([]string, 0, len(s.sharedDocs))
+	for p := range s.sharedDocs {
 		paths = append(paths, p)
 	}
 	sort.Strings(paths)
-	s.orderedPaths = paths
+	s.orderedShared = paths
 }
 
-// Get returns a doc by its relative path.
+// ---------------------------------------------------------------------------
+// Version resolution
+// ---------------------------------------------------------------------------
+
+// HasVersions reports whether the store is in versioned mode.
+func (s *Store) HasVersions() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.manifest != nil && len(s.manifest.Versions) > 0
+}
+
+// LatestVersion returns the latest release tag, or "" in legacy mode.
+func (s *Store) LatestVersion() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.manifest != nil {
+		return s.manifest.Latest
+	}
+	return ""
+}
+
+// AvailableVersions returns all version entries from the manifest.
+func (s *Store) AvailableVersions() []VersionEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.manifest == nil {
+		return nil
+	}
+	return s.manifest.Versions
+}
+
+// ResolveVersion resolves a version alias to an actual version key.
+// "latest" → manifest.Latest, "next" → manifest.Next, explicit → validated.
+// Returns an error for unknown versions. In legacy mode, returns "".
+func (s *Store) ResolveVersion(v string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.manifest == nil {
+		return "", nil // legacy mode — no versioning
+	}
+
+	switch v {
+	case "", "latest":
+		return s.manifest.Latest, nil
+	case "next":
+		return s.manifest.Next, nil
+	default:
+		// Validate against manifest
+		for _, ve := range s.manifest.Versions {
+			if ve.Version == v {
+				return v, nil
+			}
+		}
+		return "", errUnknownVersion{v}
+	}
+}
+
+// errUnknownVersion is returned when a version is not in the manifest.
+type errUnknownVersion struct{ version string }
+
+func (e errUnknownVersion) Error() string { return "unknown version: " + e.version }
+
+// ---------------------------------------------------------------------------
+// Document lookup
+// ---------------------------------------------------------------------------
+
+// Get is a legacy lookup that resolves to the latest version.
+// Prefer GetVersioned for version-specific access.
 func (s *Store) Get(path string) (Doc, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	d, ok := s.docs[path]
-	return d, ok
+
+	latest := ""
+	if s.manifest != nil {
+		latest = s.manifest.Latest
+	}
+	return s.getVersionedLocked(latest, path)
 }
 
-// AllDocs returns all docs, sorted by category order then path.
-func (s *Store) AllDocs() []Doc {
+// GetVersioned looks up a doc by version and path. Falls back to shared/in-tree
+// docs if the version-specific store doesn't have the path.
+func (s *Store) GetVersioned(version, path string) (Doc, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	var result []Doc
-	for _, p := range s.orderedPaths {
-		result = append(result, s.docs[p])
-	}
-	// Sort by category order, then path
-	sort.Slice(result, func(i, j int) bool {
-		di, dj := result[i], result[j]
-		if di.CategoryOrder != dj.CategoryOrder {
-			return di.CategoryOrder < dj.CategoryOrder
+	return s.getVersionedLocked(version, path)
+}
+
+func (s *Store) getVersionedLocked(version, path string) (Doc, bool) {
+	// Try version-specific docs first
+	if version != "" {
+		if vd, ok := s.versionDocs[version]; ok {
+			if d, found := vd[path]; found {
+				return d, true
+			}
 		}
-		return di.Path < dj.Path
-	})
+	}
+	// Fallback: shared in-tree docs
+	if d, found := s.sharedDocs[path]; found {
+		return d, true
+	}
+	return Doc{}, false
+}
+
+// ---------------------------------------------------------------------------
+// Listing (version-scoped)
+// ---------------------------------------------------------------------------
+
+// AllDocs returns all docs for a version: version-specific docs merged with
+// shared in-tree docs, sorted by category order then path.
+func (s *Store) AllDocs(version string) []Doc {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	combined := make(map[string]Doc)
+
+	// Version-specific docs
+	if version != "" {
+		if vd, ok := s.versionDocs[version]; ok {
+			for k, v := range vd {
+				combined[k] = v
+			}
+		}
+	}
+
+	// Shared in-tree docs (version-specific takes precedence on collision)
+	for k, v := range s.sharedDocs {
+		if _, exists := combined[k]; !exists {
+			combined[k] = v
+		}
+	}
+
+	result := make([]Doc, 0, len(combined))
+	for _, d := range combined {
+		result = append(result, d)
+	}
+	sortDocs(result)
 	return result
 }
 
-// Categories returns categories in display order.
-func (s *Store) Categories() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// Categories returns categories in display order for a version.
+func (s *Store) Categories(version string) []string {
+	docs := s.AllDocs(version)
 	seen := make(map[string]bool)
 	var result []string
-	for _, p := range s.orderedPaths {
-		d := s.docs[p]
+	for _, d := range docs {
 		if !seen[d.Category] {
 			seen[d.Category] = true
 			result = append(result, d.Category)
@@ -347,13 +588,11 @@ func (s *Store) Categories() []string {
 	return result
 }
 
-// DocsByCategory returns docs grouped by category, in display order.
-func (s *Store) DocsByCategory() map[string][]Doc {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+// DocsByCategory returns docs grouped by category for a version.
+func (s *Store) DocsByCategory(version string) map[string][]Doc {
+	docs := s.AllDocs(version)
 	result := make(map[string][]Doc)
-	for _, p := range s.orderedPaths {
-		d := s.docs[p]
+	for _, d := range docs {
 		result[d.Category] = append(result[d.Category], d)
 	}
 	for cat := range result {
@@ -364,9 +603,19 @@ func (s *Store) DocsByCategory() map[string][]Doc {
 	return result
 }
 
-// DocCount returns the total number of docs.
+// sortDocs sorts docs by category order then path.
+func sortDocs(docs []Doc) {
+	sort.Slice(docs, func(i, j int) bool {
+		if docs[i].CategoryOrder != docs[j].CategoryOrder {
+			return docs[i].CategoryOrder < docs[j].CategoryOrder
+		}
+		return docs[i].Path < docs[j].Path
+	})
+}
+
+// DocCount returns the total number of shared/in-tree docs.
 func (s *Store) DocCount() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return len(s.docs)
+	return len(s.sharedDocs)
 }

--- a/docs/store_version_test.go
+++ b/docs/store_version_test.go
@@ -1,0 +1,200 @@
+package docs
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testVersionedFS creates a filesystem with two versions + shared in-tree docs.
+func testVersionedFS() fstest.MapFS {
+	return fstest.MapFS{
+		// Manifest
+		"versions/manifest.json": {
+			Data: []byte(`{
+  "latest": "v1.0.0",
+  "next": "next",
+  "versions": [
+    {"version": "v1.0.0", "minor": "1.0", "date": "2026-08-01"},
+    {"version": "v0.9.0", "minor": "0.9", "date": "2026-07-01"},
+    {"version": "next", "label": "Unreleased (main)", "isNext": true}
+  ]
+}`),
+			Mode: 0644,
+		},
+		// v1.0.0 docs
+		"versions/v1.0.0/tutorials/hello.md":       {Data: []byte("# Hello v1\n\nWelcome to v1."), Mode: 0644},
+		"versions/v1.0.0/concepts/architecture.md": {Data: []byte("# Architecture v1\n"), Mode: 0644},
+		"versions/v1.0.0/tutorials/new-in-v1.md":   {Data: []byte("# New in v1\n\nAdded in v1.0.0."), Mode: 0644},
+		// v0.9.0 docs (older — no new-in-v1)
+		"versions/v0.9.0/tutorials/hello.md":       {Data: []byte("# Hello v0.9\n\nWelcome to v0.9."), Mode: 0644},
+		"versions/v0.9.0/concepts/architecture.md": {Data: []byte("# Architecture v0.9\n"), Mode: 0644},
+		// next (unreleased main)
+		"versions/next/tutorials/hello.md":       {Data: []byte("# Hello next\n\nUnreleased."), Mode: 0644},
+		"versions/next/concepts/architecture.md": {Data: []byte("# Architecture next\n"), Mode: 0644},
+		// Shared in-tree docs (platform-website's own)
+		"what-is-rezuscloud.md":         {Data: []byte("# What is RezusCloud\n\nOverview."), Mode: 0644},
+		"contributing/sourcing-docs.md": {Data: []byte("# Sourcing Docs\n"), Mode: 0644},
+	}
+}
+
+func TestVersionedStore_HasVersions(t *testing.T) {
+	store, err := NewEmbeddedStore(testVersionedFS())
+	require.NoError(t, err)
+
+	assert.True(t, store.HasVersions())
+	assert.Equal(t, "v1.0.0", store.LatestVersion())
+}
+
+func TestVersionedStore_ResolveVersion(t *testing.T) {
+	store, err := NewEmbeddedStore(testVersionedFS())
+	require.NoError(t, err)
+
+	tests := []struct {
+		input string
+		want  string
+		err   bool
+	}{
+		{"latest", "v1.0.0", false},
+		{"", "v1.0.0", false}, // empty resolves to latest
+		{"next", "next", false},
+		{"v1.0.0", "v1.0.0", false},
+		{"v0.9.0", "v0.9.0", false},
+		{"v9.9.9", "", true}, // unknown
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := store.ResolveVersion(tt.input)
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestVersionedStore_GetVersioned_VersionSpecific(t *testing.T) {
+	store, err := NewEmbeddedStore(testVersionedFS())
+	require.NoError(t, err)
+
+	// v1.0.0 has "new-in-v1" that v0.9.0 doesn't
+	doc, found := store.GetVersioned("v1.0.0", "tutorials/new-in-v1.md")
+	require.True(t, found)
+	assert.Contains(t, doc.HTML, "Added in v1.0.0")
+
+	// v0.9.0 should NOT have it
+	_, found = store.GetVersioned("v0.9.0", "tutorials/new-in-v1.md")
+	assert.False(t, found)
+}
+
+func TestVersionedStore_GetVersioned_DistinctContentPerVersion(t *testing.T) {
+	store, err := NewEmbeddedStore(testVersionedFS())
+	require.NoError(t, err)
+
+	// Same path, different content per version
+	v1doc, found := store.GetVersioned("v1.0.0", "tutorials/hello.md")
+	require.True(t, found)
+	assert.Contains(t, v1doc.HTML, "Welcome to v1")
+
+	v09doc, found := store.GetVersioned("v0.9.0", "tutorials/hello.md")
+	require.True(t, found)
+	assert.Contains(t, v09doc.HTML, "Welcome to v0.9")
+
+	nextDoc, found := store.GetVersioned("next", "tutorials/hello.md")
+	require.True(t, found)
+	assert.Contains(t, nextDoc.HTML, "Unreleased")
+}
+
+func TestVersionedStore_GetVersioned_InTreeFallback(t *testing.T) {
+	store, err := NewEmbeddedStore(testVersionedFS())
+	require.NoError(t, err)
+
+	// what-is-rezuscloud.md is an in-tree doc — available at all versions
+	for _, version := range []string{"v1.0.0", "v0.9.0", "next"} {
+		doc, found := store.GetVersioned(version, "what-is-rezuscloud.md")
+		assert.True(t, found, "in-tree doc should be found at version %s", version)
+		assert.Contains(t, doc.Title, "What is RezusCloud")
+	}
+}
+
+func TestVersionedStore_AllDocs_VersionScoped(t *testing.T) {
+	store, err := NewEmbeddedStore(testVersionedFS())
+	require.NoError(t, err)
+
+	// v1.0.0 should have: tutorials/hello, concepts/architecture, tutorials/new-in-v1,
+	//                    what-is-rezuscloud (shared), contributing/sourcing-docs (shared)
+	v1docs := store.AllDocs("v1.0.0")
+	assert.GreaterOrEqual(t, len(v1docs), 5, "v1.0.0 should have version + shared docs")
+
+	// v0.9.0 should NOT have new-in-v1
+	v09docs := store.AllDocs("v0.9.0")
+	for _, d := range v09docs {
+		assert.NotEqual(t, "tutorials/new-in-v1.md", d.Path, "v0.9.0 should not have new-in-v1")
+	}
+}
+
+func TestVersionedStore_AvailableVersions(t *testing.T) {
+	store, err := NewEmbeddedStore(testVersionedFS())
+	require.NoError(t, err)
+
+	versions := store.AvailableVersions()
+	assert.Len(t, versions, 3)
+	assert.Equal(t, "v1.0.0", versions[0].Version)
+	assert.Equal(t, "v0.9.0", versions[1].Version)
+	assert.True(t, versions[2].IsNext)
+}
+
+func TestVersionedStore_Categories_VersionScoped(t *testing.T) {
+	store, err := NewEmbeddedStore(testVersionedFS())
+	require.NoError(t, err)
+
+	cats := store.Categories("v1.0.0")
+	assert.Contains(t, cats, "tutorials")
+	assert.Contains(t, cats, "concepts")
+	assert.Contains(t, cats, "") // in-tree root docs have empty category
+
+	byCat := store.DocsByCategory("v1.0.0")
+	assert.NotEmpty(t, byCat["tutorials"])
+	assert.NotEmpty(t, byCat["concepts"])
+}
+
+func TestVersionedStore_Get_LegacyResolvesLatest(t *testing.T) {
+	store, err := NewEmbeddedStore(testVersionedFS())
+	require.NoError(t, err)
+
+	// Get() without version should resolve to latest
+	doc, found := store.Get("tutorials/hello.md")
+	require.True(t, found)
+	assert.Contains(t, doc.HTML, "Welcome to v1")
+}
+
+// --- Legacy mode tests (no manifest) ---
+
+func TestLegacyStore_NoManifest(t *testing.T) {
+	fsys := fstest.MapFS{
+		// No versions/manifest.json
+		"tutorials/hello.md":    {Data: []byte("# Hello\n"), Mode: 0644},
+		"what-is-rezuscloud.md": {Data: []byte("# Overview\n"), Mode: 0644},
+	}
+
+	store, err := NewEmbeddedStore(fsys)
+	require.NoError(t, err)
+
+	assert.False(t, store.HasVersions())
+	assert.Equal(t, "", store.LatestVersion())
+
+	// ResolveVersion returns "" in legacy mode
+	v, err := store.ResolveVersion("latest")
+	require.NoError(t, err)
+	assert.Equal(t, "", v)
+
+	// GetVersioned with "" version falls back to sharedDocs
+	doc, found := store.GetVersioned("", "tutorials/hello.md")
+	require.True(t, found)
+	assert.Contains(t, doc.Title, "Hello")
+}

--- a/handlers/docs.go
+++ b/handlers/docs.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"log"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/gofiber/fiber/v2"
@@ -13,6 +14,9 @@ import (
 
 // DocsStore is set during setup. Nil means docs are not available.
 var DocsStore *docs.Store
+
+// versionTagPattern matches explicit version prefixes like "v0.0.1-106/", "v0.1.0/".
+var versionTagPattern = regexp.MustCompile(`^v\d+\.\d+\.`)
 
 // SetupDocs initializes the documentation store.
 func SetupDocs() {
@@ -28,8 +32,17 @@ func SetupDocs() {
 	}
 
 	if store != nil {
-		allDocs := store.AllDocs()
-		log.Printf("docs: indexed %d pages across %d categories", len(allDocs), len(store.Categories()))
+		if store.HasVersions() {
+			latest := store.LatestVersion()
+			allDocs := store.AllDocs(latest)
+			versions := store.AvailableVersions()
+			log.Printf("docs: indexed %d pages across %d categories (versioned: %d versions, latest=%s)",
+				len(allDocs), len(store.Categories(latest)), len(versions), latest)
+		} else {
+			allDocs := store.AllDocs("")
+			log.Printf("docs: indexed %d pages across %d categories (legacy mode)",
+				len(allDocs), len(store.Categories("")))
+		}
 	} else {
 		log.Printf("docs: no documentation available")
 	}
@@ -43,7 +56,8 @@ func DocsIndex(c *fiber.Ctx) error {
 		return c.Status(http.StatusNotFound).SendString("Documentation not available")
 	}
 
-	allDocs := DocsStore.AllDocs()
+	latest := DocsStore.LatestVersion()
+	allDocs := DocsStore.AllDocs(latest)
 	if len(allDocs) == 0 {
 		return c.Status(http.StatusNotFound).SendString("No documentation available")
 	}
@@ -51,40 +65,97 @@ func DocsIndex(c *fiber.Ctx) error {
 	return c.Redirect("/docs/"+trimExt(allDocs[0].Path), http.StatusMovedPermanently)
 }
 
-// DocsPage renders a single documentation page.
-// Accepts paths like /docs/getting-started/install or /docs/concepts/architecture.
-func DocsPage(c *fiber.Ctx) error {
-	// Check for a redirect (renamed/moved docs) before anything else —
-	// redirects don't depend on the docs store being loaded.
-	if docPath := c.Params("*"); docPath != "" {
-		if newPath := docs.Redirect(docPath); newPath != "" {
-			return c.Redirect("/docs/"+newPath, http.StatusMovedPermanently)
+// parseVersionPrefix splits a raw doc path into (versionAlias, remainingPath).
+// Returns ("", fullPath) if no version prefix is present.
+//
+// Examples:
+//
+//	"v0.0.1-106/tutorials/install" → ("v0.0.1-106", "tutorials/install")
+//	"latest/tutorials/install"      → ("latest", "tutorials/install")
+//	"next/tutorials/install"        → ("next", "tutorials/install")
+//	"tutorials/install"             → ("", "tutorials/install")
+func parseVersionPrefix(rawPath string) (version, rest string) {
+	idx := strings.Index(rawPath, "/")
+
+	// No slash: check if entire path is a bare version alias
+	if idx < 0 {
+		if rawPath == "latest" || rawPath == "next" || versionTagPattern.MatchString(rawPath+"/") {
+			return rawPath, ""
 		}
+		return "", rawPath
+	}
+
+	// Has slash: check first segment
+	firstSeg := rawPath[:idx]
+	if firstSeg == "latest" || firstSeg == "next" || versionTagPattern.MatchString(firstSeg+"/") {
+		return firstSeg, rawPath[idx+1:]
+	}
+	return "", rawPath
+}
+
+// versionPrefixForURL returns the URL prefix for sidebar/breadcrumb links.
+// Returns "" for unversioned pages so links stay at /docs/<path>.
+func versionPrefixForURL(requestedVersion string) string {
+	if requestedVersion == "" {
+		return ""
+	}
+	return requestedVersion + "/"
+}
+
+// DocsPage renders a single documentation page.
+// Accepts paths like /docs/tutorials/install, /docs/latest/concepts/architecture,
+// /docs/v0.0.1-106/reference/cli.
+func DocsPage(c *fiber.Ctx) error {
+	rawPath := c.Params("*")
+	if rawPath == "" {
+		return DocsIndex(c)
+	}
+
+	// Parse version prefix (e.g. "latest/", "v0.0.1-106/", "next/")
+	requestedVersion, docPath := parseVersionPrefix(rawPath)
+
+	// Redirect check (version-aware) — redirects don't depend on the store.
+	if newPath := docs.Redirect(docPath); newPath != "" {
+		return c.Redirect("/docs/"+versionPrefixForURL(requestedVersion)+newPath, http.StatusMovedPermanently)
 	}
 
 	if DocsStore == nil {
 		return c.Status(http.StatusNotFound).SendString("Documentation not available")
 	}
 
-	// Build the path from the wildcard parameter
-	docPath := c.Params("*")
+	// Resolve version alias to actual version key
+	resolvedVersion, err := DocsStore.ResolveVersion(requestedVersion)
+	if err != nil {
+		return versionNotFound(c, requestedVersion)
+	}
+
 	if docPath == "" {
-		return DocsIndex(c)
-	}
-	if !strings.HasSuffix(docPath, ".md") {
-		docPath += ".md"
+		// Version root: redirect to first doc in this version
+		allDocs := DocsStore.AllDocs(resolvedVersion)
+		if len(allDocs) > 0 {
+			return c.Redirect(
+				"/docs/"+versionPrefixForURL(requestedVersion)+trimExt(allDocs[0].Path),
+				http.StatusMovedPermanently,
+			)
+		}
+		return c.Status(http.StatusNotFound).SendString("No documentation available")
 	}
 
-	doc, found := DocsStore.Get(docPath)
+	// Look up the document
+	lookupPath := docPath
+	if !strings.HasSuffix(lookupPath, ".md") {
+		lookupPath += ".md"
+	}
+
+	doc, found := DocsStore.GetVersioned(resolvedVersion, lookupPath)
 	if !found {
-		return c.Status(http.StatusNotFound).SendString("Document not found")
+		return docNotFound(c, requestedVersion, docPath)
 	}
 
-	// Extract headings for right TOC
+	// Build headings and prev/next for the resolved version
 	headings := docs.ExtractHeadings(doc.HTML)
+	allDocs := DocsStore.AllDocs(resolvedVersion)
 
-	// Build flat ordered list for prev/next
-	allDocs := DocsStore.AllDocs()
 	var prev, next *docs.Doc
 	for i, d := range allDocs {
 		if d.Path == doc.Path {
@@ -98,7 +169,32 @@ func DocsPage(c *fiber.Ctx) error {
 		}
 	}
 
-	return render(c, pages.DocsDetailPage(doc, headings, prev, next, DocsStore))
+	versionPrefix := versionPrefixForURL(requestedVersion)
+	return render(c, pages.DocsDetailPage(doc, headings, prev, next, DocsStore, resolvedVersion, versionPrefix))
+}
+
+// versionNotFound renders a 404 for an unrecognized version.
+func versionNotFound(c *fiber.Ctx, version string) error {
+	c.Status(http.StatusNotFound)
+	return c.SendString("Version " + version + " is not available. " +
+		"<a href=\"/docs\">View latest documentation</a>.")
+}
+
+// docNotFound renders a 404 for a doc that doesn't exist in the current version.
+func docNotFound(c *fiber.Ctx, requestedVersion, docPath string) error {
+	// Check if the doc exists in the latest version — if so, suggest it.
+	latest := DocsStore.LatestVersion()
+	lookupPath := docPath
+	if !strings.HasSuffix(lookupPath, ".md") {
+		lookupPath += ".md"
+	}
+
+	c.Status(http.StatusNotFound)
+	if _, exists := DocsStore.GetVersioned(latest, lookupPath); exists {
+		return c.SendString("This page is not available in this version. " +
+			"<a href=\"/docs/latest/" + docPath + "\">View in latest version</a>.")
+	}
+	return c.SendString("Document not found.")
 }
 
 func trimExt(path string) string {

--- a/handlers/docs_version_test.go
+++ b/handlers/docs_version_test.go
@@ -1,0 +1,225 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"github.com/rezuscloud/platform-website/docs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// versionedTestFS creates a docs fixture with two versions + next + shared in-tree docs.
+func versionedTestFS() fstest.MapFS {
+	return fstest.MapFS{
+		"versions/manifest.json": {
+			Data: []byte(`{
+  "latest": "v1.0.0",
+  "next": "next",
+  "versions": [
+    {"version": "v1.0.0", "minor": "1.0", "date": "2026-08-01"},
+    {"version": "v0.9.0", "minor": "0.9", "date": "2026-07-01"},
+    {"version": "next", "label": "Unreleased (main)", "isNext": true}
+  ]
+}`),
+			Mode: 0644,
+		},
+		"versions/v1.0.0/tutorials/hello.md":       {Data: []byte("# Hello v1\n\nWelcome to v1."), Mode: 0644},
+		"versions/v1.0.0/concepts/architecture.md": {Data: []byte("# Architecture v1\n"), Mode: 0644},
+		"versions/v1.0.0/tutorials/new-in-v1.md":   {Data: []byte("# New in v1\n\nAdded in v1.0.0."), Mode: 0644},
+		"versions/v0.9.0/tutorials/hello.md":       {Data: []byte("# Hello v0.9\n\nWelcome to v0.9."), Mode: 0644},
+		"versions/v0.9.0/concepts/architecture.md": {Data: []byte("# Architecture v0.9\n"), Mode: 0644},
+		"versions/next/tutorials/hello.md":         {Data: []byte("# Hello next\n\nUnreleased."), Mode: 0644},
+		"versions/next/concepts/architecture.md":   {Data: []byte("# Architecture next\n"), Mode: 0644},
+		"what-is-rezuscloud.md":                    {Data: []byte("# What is RezusCloud\n\nOverview."), Mode: 0644},
+	}
+}
+
+func setupVersionedDocsStore(t *testing.T) {
+	t.Helper()
+	store, err := docs.NewEmbeddedStore(versionedTestFS())
+	require.NoError(t, err)
+	DocsStore = store
+}
+
+func TestDocsVersion_ExplicitVersion(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	req := httptest.NewRequest("GET", "/docs/v1.0.0/tutorials/hello", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestDocsVersion_LatestAlias(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	req := httptest.NewRequest("GET", "/docs/latest/tutorials/hello", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestDocsVersion_NextAlias(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	req := httptest.NewRequest("GET", "/docs/next/tutorials/hello", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+}
+
+func TestDocsVersion_UnversionedBackwardCompat(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	// Unversioned path should serve latest (no redirect)
+	req := httptest.NewRequest("GET", "/docs/tutorials/hello", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.NotEqual(t, 301, resp.StatusCode)
+}
+
+func TestDocsVersion_InTreeSharedDoc(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	// In-tree doc should be accessible at all version prefixes
+	for _, prefix := range []string{"v1.0.0", "latest", "next", ""} {
+		t.Run(prefix, func(t *testing.T) {
+			url := "/docs/"
+			if prefix != "" {
+				url += prefix + "/"
+			}
+			url += "what-is-rezuscloud"
+			req := httptest.NewRequest("GET", url, nil)
+			resp, err := app.Test(req, -1)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			assert.Equal(t, 200, resp.StatusCode)
+		})
+	}
+}
+
+func TestDocsVersion_DocMissingInOlderVersion(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	// new-in-v1 doesn't exist in v0.9.0 → 404 with "view latest" link
+	req := httptest.NewRequest("GET", "/docs/v0.9.0/tutorials/new-in-v1", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestDocsVersion_UnknownVersion(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	// Unknown version → 404
+	req := httptest.NewRequest("GET", "/docs/v9.9.9/tutorials/hello", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 404, resp.StatusCode)
+}
+
+func TestDocsVersion_VersionAwareRedirect(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	// Version-prefixed redirect
+	req := httptest.NewRequest("GET", "/docs/latest/getting-started/index", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 301, resp.StatusCode)
+	assert.Equal(t, "/docs/latest/tutorials/install-and-first-cluster", resp.Header.Get("Location"))
+}
+
+func TestDocsVersion_VersionAwareRedirect_ExplicitVersion(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	req := httptest.NewRequest("GET", "/docs/v1.0.0/getting-started/index", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 301, resp.StatusCode)
+	assert.Equal(t, "/docs/v1.0.0/tutorials/install-and-first-cluster", resp.Header.Get("Location"))
+}
+
+func TestDocsVersion_UnversionedRedirectStillWorks(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	// Unversioned redirect (no version prefix)
+	req := httptest.NewRequest("GET", "/docs/getting-started/index", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, 301, resp.StatusCode)
+	assert.Equal(t, "/docs/tutorials/install-and-first-cluster", resp.Header.Get("Location"))
+}
+
+func TestDocsVersion_VersionRootRedirects(t *testing.T) {
+	setupVersionedDocsStore(t)
+	app := setupApp()
+
+	// /docs/latest/ → redirect to first doc in latest
+	req := httptest.NewRequest("GET", "/docs/latest", nil)
+	resp, err := app.Test(req, -1)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Should redirect (301) to a doc within the latest version
+	assert.Equal(t, 301, resp.StatusCode)
+	loc := resp.Header.Get("Location")
+	assert.Contains(t, loc, "/docs/latest/")
+}
+
+func TestParseVersionPrefix(t *testing.T) {
+	tests := []struct {
+		input   string
+		version string
+		rest    string
+	}{
+		{"v0.0.1-106/tutorials/install", "v0.0.1-106", "tutorials/install"},
+		{"v1.0.0/concepts/arch", "v1.0.0", "concepts/arch"},
+		{"latest/tutorials/install", "latest", "tutorials/install"},
+		{"next/tutorials/install", "next", "tutorials/install"},
+		{"tutorials/install", "", "tutorials/install"},
+		{"what-is-rezuscloud", "", "what-is-rezuscloud"},
+		// Bare version aliases (no trailing path)
+		{"latest", "latest", ""},
+		{"next", "next", ""},
+		{"v1.0.0", "v1.0.0", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			v, r := parseVersionPrefix(tt.input)
+			assert.Equal(t, tt.version, v)
+			assert.Equal(t, tt.rest, r)
+		})
+	}
+}

--- a/views/pages/docs.templ
+++ b/views/pages/docs.templ
@@ -30,22 +30,23 @@ templ docsSearch() {
 }
 
 // docsSidebar renders a unified sidebar organized by topic category.
-templ docsSidebar(activeKey string, store *docs.Store) {
+// versionPrefix is prepended to all doc links (e.g. "latest/", "v0.0.1-106/", or "").
+templ docsSidebar(activeKey string, store *docs.Store, version string, versionPrefix string) {
 	<aside class="hidden lg:block w-[18rem] flex-shrink-0" aria-label="Documentation navigation">
 		<nav class="sticky top-16 h-[calc(100vh-4rem)] overflow-y-auto px-4 py-6">
 			@docsSearch()
 			<div class="mt-4 space-y-6">
-				for _, cat := range store.Categories() {
+				for _, cat := range store.Categories(version) {
 					<div data-doc-group>
 						<p class="font-silkscreen text-[10px] uppercase tracking-wider text-ink-muted dark:text-next-subtle-text mb-2 px-2">
 							{ docs.CategoryDisplayName(cat) }
 						</p>
 						<ul>
-							for _, d := range store.DocsByCategory()[cat] {
+							for _, d := range store.DocsByCategory(version)[cat] {
 								<li>
 									if d.Path == activeKey {
 										<a
-											href={ "/docs/" + trimExt(d.Path) }
+											href={ "/docs/" + versionPrefix + trimExt(d.Path) }
 											data-doc-link
 											data-title={ d.Title }
 											class="block py-1.5 px-3 text-sm font-semibold text-accent-gold-text dark:text-next-teal-text bg-surface-strong dark:bg-next-dark"
@@ -54,7 +55,7 @@ templ docsSidebar(activeKey string, store *docs.Store) {
 										</a>
 									} else {
 										<a
-											href={ "/docs/" + trimExt(d.Path) }
+											href={ "/docs/" + versionPrefix + trimExt(d.Path) }
 											data-doc-link
 											data-title={ d.Title }
 											class="block py-1.5 px-3 text-sm text-ink-muted dark:text-next-subtle-text hover:text-ink dark:hover:text-next-white hover:bg-surface dark:hover:bg-next-dark transition-colors"
@@ -73,7 +74,7 @@ templ docsSidebar(activeKey string, store *docs.Store) {
 }
 
 // docsMobileNav renders a collapsible mobile navigation drawer.
-templ docsMobileNav(activeKey string, store *docs.Store) {
+templ docsMobileNav(activeKey string, store *docs.Store, version string, versionPrefix string) {
 	<div class="lg:hidden" x-data="{ open: false }">
 		<button
 			@click="open = !open"
@@ -97,19 +98,19 @@ templ docsMobileNav(activeKey string, store *docs.Store) {
 			class="mt-4 border border-rule dark:border-next-mid p-4 max-h-[60vh] overflow-y-auto"
 			aria-label="Documentation navigation"
 		>
-			for _, cat := range store.Categories() {
+			for _, cat := range store.Categories(version) {
 				<p class="font-silkscreen text-[10px] uppercase tracking-wider text-ink-muted dark:text-next-subtle-text mb-1 px-2">
 					{ docs.CategoryDisplayName(cat) }
 				</p>
 				<ul class="mb-3">
-					for _, d := range store.DocsByCategory()[cat] {
+					for _, d := range store.DocsByCategory(version)[cat] {
 						<li>
 							if d.Path == activeKey {
-								<a href={ "/docs/" + trimExt(d.Path) } class="block py-1 px-2 text-sm font-semibold text-accent-gold-text dark:text-next-teal-text">
+								<a href={ "/docs/" + versionPrefix + trimExt(d.Path) } class="block py-1 px-2 text-sm font-semibold text-accent-gold-text dark:text-next-teal-text">
 									{ d.Title }
 								</a>
 							} else {
-								<a href={ "/docs/" + trimExt(d.Path) } class="block py-1 px-2 text-sm text-ink-muted dark:text-next-subtle-text hover:text-ink dark:hover:text-next-white">
+								<a href={ "/docs/" + versionPrefix + trimExt(d.Path) } class="block py-1 px-2 text-sm text-ink-muted dark:text-next-subtle-text hover:text-ink dark:hover:text-next-white">
 									{ d.Title }
 								</a>
 							}
@@ -164,12 +165,12 @@ templ docsEditLink(githubURL string) {
 }
 
 // docsPrevNext renders prev/next page navigation at the bottom of content.
-templ docsPrevNext(prev *docs.Doc, next *docs.Doc) {
+templ docsPrevNext(prev *docs.Doc, next *docs.Doc, versionPrefix string) {
 	if prev != nil || next != nil {
 		<nav class="flex items-center justify-between mt-12 pt-6 border-t border-rule dark:border-next-mid" aria-label="Pagination">
 			if prev != nil {
 				<a
-					href={ "/docs/" + trimExt(prev.Path) }
+					href={ "/docs/" + versionPrefix + trimExt(prev.Path) }
 					class="group flex flex-col items-start max-w-[45%]"
 				>
 					<span class="text-[10px] font-silkscreen uppercase tracking-wider text-ink-muted dark:text-next-subtle-text mb-1">Previous</span>
@@ -182,7 +183,7 @@ templ docsPrevNext(prev *docs.Doc, next *docs.Doc) {
 			}
 			if next != nil {
 				<a
-					href={ "/docs/" + trimExt(next.Path) }
+					href={ "/docs/" + versionPrefix + trimExt(next.Path) }
 					class="group flex flex-col items-end text-right max-w-[45%]"
 				>
 					<span class="text-[10px] font-silkscreen uppercase tracking-wider text-ink-muted dark:text-next-subtle-text mb-1">Next</span>
@@ -196,7 +197,9 @@ templ docsPrevNext(prev *docs.Doc, next *docs.Doc) {
 }
 
 // DocsDetailPage renders a single documentation page with the standard three-column layout.
-templ DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next *docs.Doc, store *docs.Store) {
+// version is the resolved version key (e.g. "v0.0.1-106"); versionPrefix is the URL
+// prefix for links (e.g. "latest/", "v0.0.1-106/", or "" for unversioned).
+templ DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next *docs.Doc, store *docs.Store, version string, versionPrefix string) {
 	@views.Layout(doc.Title+" | RezusCloud Documentation", "docs") {
 		<section class="min-h-screen bg-paper dark:bg-next-black pt-14">
 			<!-- Breadcrumb -->
@@ -205,7 +208,7 @@ templ DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next
 					<nav class="text-xs font-silkscreen text-ink-muted dark:text-next-subtle-text" aria-label="Breadcrumb">
 						<a href="/docs" class="hover:text-accent-gold-text dark:hover:text-next-teal-text transition-colors">Documentation</a>
 						<span class="mx-2 text-rule dark:text-next-mid">/</span>
-						<a href={ "/docs/" + doc.Category } class="hover:text-accent-gold-text dark:hover:text-next-teal-text transition-colors">
+						<a href={ "/docs/" + versionPrefix + doc.Category } class="hover:text-accent-gold-text dark:hover:text-next-teal-text transition-colors">
 							{ docs.CategoryDisplayName(doc.Category) }
 						</a>
 						<span class="mx-2 text-rule dark:text-next-mid">/</span>
@@ -216,11 +219,11 @@ templ DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next
 			<!-- Three-column layout -->
 			<div class="mx-auto max-w-[90rem] px-0 lg:grid lg:grid-cols-[18rem_minmax(0,1fr)_14rem] xl:grid-cols-[18rem_minmax(0,1fr)_14rem]">
 				<!-- Left sidebar (desktop) -->
-				@docsSidebar(doc.Path, store)
+				@docsSidebar(doc.Path, store, version, versionPrefix)
 				<!-- Content -->
 				<main class="min-w-0 px-4 sm:px-6 lg:px-8 py-8">
 					<!-- Mobile nav toggle -->
-					@docsMobileNav(doc.Path, store)
+					@docsMobileNav(doc.Path, store, version, versionPrefix)
 					<!-- Page title -->
 					<h1 class="font-silkscreen text-2xl sm:text-3xl text-ink dark:text-next-white tracking-tight mb-6">
 						{ doc.Title }
@@ -261,7 +264,7 @@ templ DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next
 						@docsEditLink(doc.GitHubEditURL)
 					</div>
 					<!-- Prev/Next -->
-					@docsPrevNext(prev, next)
+					@docsPrevNext(prev, next, versionPrefix)
 				</main>
 				<!-- Right TOC (desktop) -->
 				@docsRightTOC(headings)

--- a/views/pages/docs_templ.go
+++ b/views/pages/docs_templ.go
@@ -44,7 +44,8 @@ func docsSearch() templ.Component {
 }
 
 // docsSidebar renders a unified sidebar organized by topic category.
-func docsSidebar(activeKey string, store *docs.Store) templ.Component {
+// versionPrefix is prepended to all doc links (e.g. "latest/", "v0.0.1-106/", or "").
+func docsSidebar(activeKey string, store *docs.Store, version string, versionPrefix string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -77,7 +78,7 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, cat := range store.Categories() {
+		for _, cat := range store.Categories(version) {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div data-doc-group><p class=\"font-silkscreen text-[10px] uppercase tracking-wider text-ink-muted dark:text-next-subtle-text mb-2 px-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -85,7 +86,7 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(docs.CategoryDisplayName(cat))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 41, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 42, Col: 38}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -95,7 +96,7 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, d := range store.DocsByCategory()[cat] {
+			for _, d := range store.DocsByCategory(version)[cat] {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<li>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -106,9 +107,9 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var4 templ.SafeURL
-					templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + trimExt(d.Path))
+					templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + versionPrefix + trimExt(d.Path))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 48, Col: 44}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 49, Col: 60}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 					if templ_7745c5c3_Err != nil {
@@ -121,7 +122,7 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 					var templ_7745c5c3_Var5 string
 					templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.ResolveAttributeValue(d.Title)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 50, Col: 31}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 51, Col: 31}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5)
 					if templ_7745c5c3_Err != nil {
@@ -134,7 +135,7 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 					var templ_7745c5c3_Var6 string
 					templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(d.Title)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 53, Col: 20}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 54, Col: 20}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 					if templ_7745c5c3_Err != nil {
@@ -150,9 +151,9 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var7 templ.SafeURL
-					templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + trimExt(d.Path))
+					templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + versionPrefix + trimExt(d.Path))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 57, Col: 44}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 58, Col: 60}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 					if templ_7745c5c3_Err != nil {
@@ -165,7 +166,7 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 					var templ_7745c5c3_Var8 string
 					templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(d.Title)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 59, Col: 31}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 60, Col: 31}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 					if templ_7745c5c3_Err != nil {
@@ -178,7 +179,7 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 					var templ_7745c5c3_Var9 string
 					templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(d.Title)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 62, Col: 20}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 63, Col: 20}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 					if templ_7745c5c3_Err != nil {
@@ -208,7 +209,7 @@ func docsSidebar(activeKey string, store *docs.Store) templ.Component {
 }
 
 // docsMobileNav renders a collapsible mobile navigation drawer.
-func docsMobileNav(activeKey string, store *docs.Store) templ.Component {
+func docsMobileNav(activeKey string, store *docs.Store, version string, versionPrefix string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -233,7 +234,7 @@ func docsMobileNav(activeKey string, store *docs.Store) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, cat := range store.Categories() {
+		for _, cat := range store.Categories(version) {
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<p class=\"font-silkscreen text-[10px] uppercase tracking-wider text-ink-muted dark:text-next-subtle-text mb-1 px-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -241,7 +242,7 @@ func docsMobileNav(activeKey string, store *docs.Store) templ.Component {
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(docs.CategoryDisplayName(cat))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 102, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 103, Col: 36}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -251,7 +252,7 @@ func docsMobileNav(activeKey string, store *docs.Store) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, d := range store.DocsByCategory()[cat] {
+			for _, d := range store.DocsByCategory(version)[cat] {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<li>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -262,9 +263,9 @@ func docsMobileNav(activeKey string, store *docs.Store) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var12 templ.SafeURL
-					templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + trimExt(d.Path))
+					templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + versionPrefix + trimExt(d.Path))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 108, Col: 44}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 109, Col: 60}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 					if templ_7745c5c3_Err != nil {
@@ -277,7 +278,7 @@ func docsMobileNav(activeKey string, store *docs.Store) templ.Component {
 					var templ_7745c5c3_Var13 string
 					templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(d.Title)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 109, Col: 18}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 110, Col: 18}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 					if templ_7745c5c3_Err != nil {
@@ -293,9 +294,9 @@ func docsMobileNav(activeKey string, store *docs.Store) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var14 templ.SafeURL
-					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + trimExt(d.Path))
+					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + versionPrefix + trimExt(d.Path))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 112, Col: 44}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 113, Col: 60}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 					if templ_7745c5c3_Err != nil {
@@ -308,7 +309,7 @@ func docsMobileNav(activeKey string, store *docs.Store) templ.Component {
 					var templ_7745c5c3_Var15 string
 					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(d.Title)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 113, Col: 18}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 114, Col: 18}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 					if templ_7745c5c3_Err != nil {
@@ -391,7 +392,7 @@ func docsRightTOC(headings []docs.Heading) templ.Component {
 					var templ_7745c5c3_Var19 templ.SafeURL
 					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinURLErrs("#" + h.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 135, Col: 26}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 136, Col: 26}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 					if templ_7745c5c3_Err != nil {
@@ -404,7 +405,7 @@ func docsRightTOC(headings []docs.Heading) templ.Component {
 					var templ_7745c5c3_Var20 string
 					templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(h.Text)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 138, Col: 17}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 139, Col: 17}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 					if templ_7745c5c3_Err != nil {
@@ -455,7 +456,7 @@ func docsEditLink(githubURL string) templ.Component {
 			var templ_7745c5c3_Var22 templ.SafeURL
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(githubURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 153, Col: 19}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 154, Col: 19}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -471,7 +472,7 @@ func docsEditLink(githubURL string) templ.Component {
 }
 
 // docsPrevNext renders prev/next page navigation at the bottom of content.
-func docsPrevNext(prev *docs.Doc, next *docs.Doc) templ.Component {
+func docsPrevNext(prev *docs.Doc, next *docs.Doc, versionPrefix string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -503,9 +504,9 @@ func docsPrevNext(prev *docs.Doc, next *docs.Doc) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var24 templ.SafeURL
-				templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + trimExt(prev.Path))
+				templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + versionPrefix + trimExt(prev.Path))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 172, Col: 41}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 173, Col: 57}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 				if templ_7745c5c3_Err != nil {
@@ -518,7 +519,7 @@ func docsPrevNext(prev *docs.Doc, next *docs.Doc) templ.Component {
 				var templ_7745c5c3_Var25 string
 				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(prev.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 177, Col: 18}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 178, Col: 18}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 				if templ_7745c5c3_Err != nil {
@@ -540,9 +541,9 @@ func docsPrevNext(prev *docs.Doc, next *docs.Doc) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var26 templ.SafeURL
-				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + trimExt(next.Path))
+				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + versionPrefix + trimExt(next.Path))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 185, Col: 41}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 186, Col: 57}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 				if templ_7745c5c3_Err != nil {
@@ -555,7 +556,7 @@ func docsPrevNext(prev *docs.Doc, next *docs.Doc) templ.Component {
 				var templ_7745c5c3_Var27 string
 				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(next.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 190, Col: 18}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 191, Col: 18}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 				if templ_7745c5c3_Err != nil {
@@ -576,7 +577,9 @@ func docsPrevNext(prev *docs.Doc, next *docs.Doc) templ.Component {
 }
 
 // DocsDetailPage renders a single documentation page with the standard three-column layout.
-func DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next *docs.Doc, store *docs.Store) templ.Component {
+// version is the resolved version key (e.g. "v0.0.1-106"); versionPrefix is the URL
+// prefix for links (e.g. "latest/", "v0.0.1-106/", or "" for unversioned).
+func DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next *docs.Doc, store *docs.Store, version string, versionPrefix string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -614,9 +617,9 @@ func DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next 
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var30 templ.SafeURL
-			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + doc.Category)
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs("/docs/" + versionPrefix + doc.Category)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 208, Col: 39}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 211, Col: 55}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
@@ -629,7 +632,7 @@ func DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next 
 			var templ_7745c5c3_Var31 string
 			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(docs.CategoryDisplayName(doc.Category))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 209, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 212, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
@@ -642,7 +645,7 @@ func DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next 
 			var templ_7745c5c3_Var32 string
 			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(doc.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 212, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 215, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 			if templ_7745c5c3_Err != nil {
@@ -652,7 +655,7 @@ func DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = docsSidebar(doc.Path, store).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = docsSidebar(doc.Path, store, version, versionPrefix).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -660,7 +663,7 @@ func DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = docsMobileNav(doc.Path, store).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = docsMobileNav(doc.Path, store, version, versionPrefix).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -671,7 +674,7 @@ func DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next 
 			var templ_7745c5c3_Var33 string
 			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(doc.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 226, Col: 17}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `views/pages/docs.templ`, Line: 229, Col: 17}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
@@ -697,7 +700,7 @@ func DocsDetailPage(doc docs.Doc, headings []docs.Heading, prev *docs.Doc, next 
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = docsPrevNext(prev, next).Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = docsPrevNext(prev, next, versionPrefix).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
Closes #110.

Core backend for versioned documentation. The Store supports two loading modes, the handler routes version-prefixed URLs, and templates are version-aware.

## Store architecture

**Two modes:**
- **Versioned**: `versions/manifest.json` present → per-version doc maps + shared in-tree docs
- **Legacy**: no manifest → flat map (backward compat with pre-versioning images)

**Versioned mode data model:**
```
versionDocs: map[version]map[path]Doc   // version-specific (from versions/<tag>/)
sharedDocs:   map[path]Doc              // in-tree (what-is-rezuscloud.md, contributing/)
```

Lookup: `GetVersioned(version, path)` tries version-specific docs, falls back to shared in-tree docs.

## URL routing

| URL | Behavior |
|-----|----------|
| `/docs/v0.0.1-106/tutorials/install` | Serve docs from that release |
| `/docs/latest/tutorials/install` | Resolve to latest release |
| `/docs/next/tutorials/install` | Serve unreleased main docs |
| `/docs/tutorials/install` | Backward-compatible — serve latest, URL unchanged |
| `/docs/v0.0.1-999/...` | 404 — unknown version, "view latest" link |
| `/docs/v0.9.0/new-feature` | 404 — doc not in this version, "view latest" link |

Version-aware redirects: `/docs/v1.0.0/getting-started/index` → `/docs/v1.0.0/tutorials/install-and-first-cluster`

## Tests (25 new)

**Store** (12): version resolution, versioned lookup, distinct content per version, in-tree fallback, version-scoped listing, legacy mode, manifest parsing

**Handler** (13): all URL shapes, version-aware redirects, unknown version, missing doc, parseVersionPrefix unit tests

## Next

- #111: Version switcher UI + canonical links
- #112: Docker + GoReleaser wiring