### PR TITLE
fix: Docker + GoReleaser wiring for versioned docs

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -42,7 +42,7 @@ dockers_v2:
       - latest
     extra_files:
       - assets
-      - docs/external
+      - docs/versions
       - docs/what-is-rezuscloud.md
       - docs/contributing
     labels:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Free port 3000
         run: sudo fuser -k 3000/tcp 2>/dev/null || true
 
+      - name: Fetch docs
+        run: bash scripts/fetch-docs.sh
+
       - name: Build container
         run: |
           docker rm -f platform-website 2>/dev/null || true

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,9 +1,0 @@
-FROM gcr.io/distroless/static-debian12:nonroot
-WORKDIR /app
-ARG TARGETPLATFORM
-COPY $TARGETPLATFORM/platform-website /app/server
-COPY assets/ /app/assets/
-COPY docs/external/ /app/docs/external/
-EXPOSE 3000
-USER nonroot:nonroot
-ENTRYPOINT ["/app/server"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY ${TARGETPLATFORM}/platform-website /app/server
 COPY assets /app/assets
-COPY docs/external /app/docs/external
+COPY docs/versions /app/docs/versions
 COPY docs/what-is-rezuscloud.md /app/docs/
 COPY docs/contributing /app/docs/contributing
 


### PR DESCRIPTION
Closes #112. Final piece of the versioned documentation milestone.

## Changes

- **Dockerfile.release**: `COPY docs/external` -> `COPY docs/versions`
- **GoReleaser extra_files**: `docs/external` -> `docs/versions`
- **Delete Dockerfile.goreleaser**: dead file from initial setup (#10), superseded by Dockerfile.release (#77), not referenced anywhere
- **CI e2e-test**: add `fetch-docs.sh` step so E2E tests have real versioned docs to exercise

## Production image contents after this

```
docs/versions/          manifest.json + per-tag doc trees
docs/what-is-rezuscloud.md   in-tree shared
docs/contributing/           in-tree shared
```

The Store from #110 will detect manifest.json and enter versioned mode automatically.

## Closes milestone #1

This is the last issue in the Versioned documentation milestone. After merge: milestone complete.