### PR TITLE
fix: fetch-docs.sh release listing fallback via git ls-remote

### DIFF
--- a/scripts/fetch-docs.sh
+++ b/scripts/fetch-docs.sh
@@ -107,10 +107,23 @@ fi
 
 echo "Querying releases from ${ORG}/${REPO}..."
 ALL_RELEASES=$(gh release list --repo "${ORG}/${REPO}" --json tagName,createdAt --limit 500 2>/dev/null | \
-    jq -r '.[] | "\(.createdAt)\t\(.tagName)"' || echo "")
+    jq -r '.[] | "\(.createdAt)\t\(.tagName)"' 2>/dev/null || echo "")
 
 if [ -z "$ALL_RELEASES" ]; then
-    echo "  No releases found (or gh not authenticated). Fetching next only."
+    echo "  gh release list failed (cross-repo auth or network). Falling back to git ls-remote..."
+    # Fallback: list tags via git ls-remote (works for public repos without auth).
+    # No release dates available in this path.
+    TAGS_RAW=$(git ls-remote --tags "https://github.com/${ORG}/${REPO}.git" 2>/dev/null | \
+        grep -oP 'refs/tags/\Kv\d+\.\d+\.[^^]+$' || echo "")
+    if [ -n "$TAGS_RAW" ]; then
+        # Format as empty-date\ttag to match gh release list format
+        ALL_RELEASES=$(echo "$TAGS_RAW" | while IFS= read -r tag; do
+            printf '\t%s\n' "$tag"
+        done)
+        echo "  Found $(echo "$ALL_RELEASES" | wc -l) tags via git ls-remote"
+    else
+        echo "  No tags found via git ls-remote either. Fetching next only."
+    fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #117.

## Problem

After deploying versioned docs (#109-#112), only `/docs/next/` works in production. The GoReleaser build token (GITHUB_TOKEN) is scoped to platform-website and cannot access rezuscloud/rezuscloud releases via `gh release list`. The error was silently swallowed, resulting in zero release versions — only `next` was fetched.

## Fix

Add `git ls-remote --tags` fallback when `gh release list` fails. Works for public repos without authentication. Release dates unavailable in this path (empty in manifest).

The tarball download for individual versions already has a git clone fallback, so once the tag LIST is available, fetching each version works.