### PR TITLE
fix(release): goreleaser docker → docs/external (unblock production deploy)

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -42,8 +42,7 @@ dockers_v2:
       - latest
     extra_files:
       - assets
-      - docs/versions
-      - docs/what-is-rezuscloud.md
+      - docs/external
       - docs/contributing
     labels:
       org.opencontainers.image.title: RezusCloud Platform Website

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -6,8 +6,7 @@ WORKDIR /app
 
 COPY ${TARGETPLATFORM}/platform-website /app/server
 COPY assets /app/assets
-COPY docs/versions /app/docs/versions
-COPY docs/what-is-rezuscloud.md /app/docs/
+COPY docs/external /app/docs/external
 COPY docs/contributing /app/docs/contributing
 
 EXPOSE 3000


### PR DESCRIPTION
Closes #122.

The release build has failed on every master push since #120 retired per-release versioning — `release.yml` errors `failed to copy extra file 'docs/versions': lstat docs/versions: no such file`. No release image published → Flux stuck on July `v1.9.0-34` → production still serves versioned URLs and leaks internal docs.

`fetch-docs.sh` now produces `docs/external/<repo>/` (cloned wikis). Point the goreleaser docker path at it:

- `goreleaser.yaml` `extra_files`: drop `docs/versions` + `docs/what-is-rezuscloud.md`, add `docs/external`
- `Dockerfile.release`: `COPY docs/external /app/docs/external`

**Verified locally:** ran `fetch-docs.sh`, then built `Dockerfile.release` (all COPYs resolve, image builds). The ci.yml `Dockerfile` path was already correct in #120; only the release path was missed.