### PR TITLE
docs(sourcing): fix taxonomy + clarify release propagation

### DIFF
--- a/docs/contributing/sourcing-docs.md
+++ b/docs/contributing/sourcing-docs.md
@@ -13,15 +13,19 @@ context, which are never served here.
 
 `scripts/fetch-docs.sh` clones both wikis (public, no auth) into `docs/external/`.
 It runs in CI (`ci.yml` build + docker-pr jobs) and as a goreleaser `before` hook,
-so production images always carry fresh docs.
+so production images always carry fresh docs. Doc content therefore deploys the
+next time a release image is built (push to `master`): the docs are baked in at
+build time, not fetched at runtime, so a wiki edit on its own does not roll a
+new image.
 
 ## Why wikis
 
 A wiki is a single HEAD of user-facing docs. Because it contains no ADRs and no
 archived decision history, internal content **cannot leak** onto the public docs
 site. The store's Diátaxis category allowlist (`docs/store.go`) is the second
-line of defense: only `tutorials/`, `how-to/`, `reference/`, `concepts/`, and
-root-level `Overview` pages are served — everything else is ignored.
+line of defense: only `tutorials/`, `how-to/`, `reference/`, `concepts/`, `operations/`,
+and root-level pages (e.g. the product intro, documentation standards) are
+served — everything else is ignored.
 
 ADRs stay co-located with the code in each repo's `docs/adr/` (deeply
 cross-referenced; co-versioned with the implementation).
@@ -37,6 +41,7 @@ The sidebar follows the [Diátaxis](https://diataxis.fr/) framework:
 | `how-to/` | How-to Guides | Task-oriented: solve a specific problem |
 | `reference/` | Reference | Information-oriented: precise, complete, structured |
 | `concepts/` | Concepts | Understanding-oriented: deep, discursive |
+| `operations/` | Operations | Production deployment + runbooks |
 
 ## Local development
 


### PR DESCRIPTION
Small accuracy fixes to `sourcing-docs.md`: add the missing `operations/` category to the Diátaxis table; root-level serving covers any root page (not only 'Overview'); and note that wiki edits roll out on the next release build (docs are baked in at build time). Triggers a release that picks up the wiki's new `documentation-standards` page.